### PR TITLE
Remove simulate transaction cost

### DIFF
--- a/erdpy/interfaces.py
+++ b/erdpy/interfaces.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any, Dict, Protocol
 from erdpy.utils import ISerializable
 
 
@@ -44,9 +44,6 @@ class IAccount:
         return ""
 
 
-class ISimulateResponse(ISerializable):
-    pass
-
-
-class ISimulateCostResponse(ISerializable):
-    pass
+class ISimulateResponse(Protocol):
+    def to_dictionary(self) -> Dict[str, Any]:
+        ...

--- a/erdpy/simulation.py
+++ b/erdpy/simulation.py
@@ -1,26 +1,21 @@
 from collections import OrderedDict
 from typing import Any, Dict, Protocol
-from erdpy.interfaces import ISimulateCostResponse, ISimulateResponse, ITransaction
+from erdpy.interfaces import ISimulateResponse, ITransaction
 from erdpy.utils import ISerializable
 
 
 class INetworkProvider(Protocol):
-    def simulate_transaction(self, transaction: Dict[str, Any]) -> ISimulateResponse:
-        ...
-    
-    def simulate_transaction_cost(self, transaction: Dict[str, Any]) -> ISimulateCostResponse:
+    def simulate_transaction(self, transaction: ITransaction) -> ISimulateResponse:
         ...
 
 
 class Simulation(ISerializable):
-    def __init__(self, simulate_response: ISimulateResponse, simulate_cost_response: ISimulateCostResponse) -> None:
+    def __init__(self, simulate_response: ISimulateResponse) -> None:
         self.simulation_response = simulate_response
-        self.cost_simulation_response = simulate_cost_response
 
     def to_dictionary(self) -> Dict[str, Any]:
         dictionary: Dict[str, Any] = OrderedDict()
         dictionary["execution"] = self.simulation_response.to_dictionary()
-        dictionary["cost"] = self.cost_simulation_response.to_dictionary()
 
         return dictionary
 
@@ -29,9 +24,6 @@ class Simulator():
         self.proxy = proxy
 
     def run(self, transaction: ITransaction) -> Simulation:
-        dictionary = transaction.to_dictionary()
-        simulation_response = self.proxy.simulate_transaction(dictionary)
-        cost_simulation_response = self.proxy.simulate_transaction_cost(dictionary)
+        simulation_response = self.proxy.simulate_transaction(transaction)
 
-        return Simulation(simulation_response, cost_simulation_response)
-
+        return Simulation(simulation_response)


### PR DESCRIPTION
After a discussion with @andreibancioiu we've decided that the simulate transaction cost is no longer used and relevant so it should be deleted.