### PR TITLE
Allow to run tests recursively

### DIFF
--- a/multiversx_sdk_cli/cli_contracts.py
+++ b/multiversx_sdk_cli/cli_contracts.py
@@ -52,6 +52,7 @@ def setup_parser(args: List[str], subparsers: Any) -> Any:
     sub.add_argument("--directory", default="scenarios",
                      help="🗀 the directory containing the tests (default: %(default)s)")
     sub.add_argument("--wildcard", required=False, help="wildcard to match only specific test files")
+    _add_recursive_arg(sub)
     sub.set_defaults(func=run_tests)
 
     sub = cli_shared.add_command_subparser(subparsers, "contract", "report", "Print a detailed report of the smart contracts.")
@@ -279,7 +280,9 @@ def do_report(args: Any):
 
 
 def run_tests(args: Any):
-    projects.run_tests(args)
+    project_paths = get_project_paths(args)
+    for project in project_paths:
+        projects.run_tests(project, args)
 
 
 def deploy(args: Any):

--- a/multiversx_sdk_cli/projects/core.py
+++ b/multiversx_sdk_cli/projects/core.py
@@ -53,8 +53,7 @@ def clean_project(directory: Path):
     logger.info("Project cleaned.")
 
 
-def run_tests(args: Any):
-    project_path = Path(args.project)
+def run_tests(project_path: Path, args: Any):
     directory = Path(args.directory)
     wildcard = args.wildcard
 

--- a/multiversx_sdk_cli/tests/test_cli_contracts.sh
+++ b/multiversx_sdk_cli/tests/test_cli_contracts.sh
@@ -62,7 +62,7 @@ testRunScenarios() {
     ${CLI} --verbose contract test --directory="scenarios" ${SANDBOX}/myadder-rs || return 1
     ${CLI} --verbose contract test --directory="scenarios" ${SANDBOX}/mybubbles-rs || return 1
     ${CLI} --verbose contract test --directory="scenarios" ${SANDBOX}/mylottery-rs || return 1
-    ${CLI} --verbose contract test --directory="scenarios" ${SANDBOX}/myfunding-rs || return 1
+    ${CLI} --verbose contract test --directory="scenarios" --recursive ${SANDBOX}/myfunding-rs || return 1
 }
 
 testWasmName() {


### PR DESCRIPTION
If a folder `a` contains two smart contracts `a/sc1` and `a/sc2`, then executing `mxpy contract test --recursive` will run the tests in both smart contract folders. This is similar to `mxpy contract build --recursive`.