### PR TITLE
Set default platform by default + flag to skip setting it

### DIFF
--- a/multiversx_sdk_cli/cli_contracts.py
+++ b/multiversx_sdk_cli/cli_contracts.py
@@ -158,6 +158,8 @@ def setup_parser(args: List[str], subparsers: Any) -> Any:
     sub.add_argument("--contract", type=str, help="relative path of the contract in the project")
     sub.add_argument("--no-docker-interactive", action="store_true", default=False)
     sub.add_argument("--no-docker-tty", action="store_true", default=False)
+    sub.add_argument("--no-default-platform", action="store_true", default=False,
+                     help="do not set DOCKER_DEFAULT_PLATFORM environment variable to 'linux/amd64'")
     sub.set_defaults(func=do_reproducible_build)
 
     parser.epilog = cli_shared.build_group_epilog(subparsers)
@@ -441,6 +443,7 @@ def do_reproducible_build(args: Any):
     contract_path = args.contract
     docker_interactive = not args.no_docker_interactive
     docker_tty = not args.no_docker_tty
+    no_default_platform = args.no_default_platform
 
     project_path = Path(project_path).expanduser().resolve()
     output_path = project_path / "output-docker"
@@ -455,7 +458,7 @@ def do_reproducible_build(args: Any):
         raise DockerMissingError()
 
     logger.info("Starting the docker run...")
-    run_docker(docker_image, project_path, contract_path, output_path, no_wasm_opt, docker_interactive, docker_tty)
+    run_docker(docker_image, project_path, contract_path, output_path, no_wasm_opt, docker_interactive, docker_tty, no_default_platform)
 
     logger.info("Docker build ran successfully!")
     logger.info(f"Inspect summary of generated artifacts here: {artifacts_path}")

--- a/multiversx_sdk_cli/docker.py
+++ b/multiversx_sdk_cli/docker.py
@@ -31,6 +31,7 @@ def run_docker(
         no_wasm_opt: bool,
         docker_interactive: bool,
         docker_tty: bool,
+        no_default_platform: bool
 ):
     docker_mount_args: List[str] = ["--volume", f"{output_path}:/output"]
 
@@ -47,6 +48,9 @@ def run_docker(
     docker_args += docker_mount_args
     docker_args += ["--user", f"{str(os.getuid())}:{str(os.getgid())}"]
     docker_args += ["--rm", image]
+
+    if not(no_default_platform):
+        docker_args += ["--platform", "linux/amd64"]
 
     entrypoint_args: List[str] = []
 


### PR DESCRIPTION
A developer on Mac M1 who wants to do a reproducible build has to first set the `DOCKER_DEFAULT_PLATFORM` environment variable to "linux/amd64". If he/she doesn't know or forgets, the build might not be reproducible.

Having to think about adding this flag is friction for reproducible builds. Hence `mxpy` would set it by default. As setting this flag can significantly slow the build process on Mac M1, we let the option to skip setting it with the flag `--no-default-platform`.

Docker documentation about `--platform` and `DOCKER_DEFAULT_PLATFORM`:

> DOCKER_DEFAULT_PLATFORM | Default platform for commands that take the --platform flag.

https://docs.docker.com/engine/reference/commandline/cli/#environment-variables