### PR TITLE
Do not use a global "testnet.toml" anymore

### DIFF
--- a/multiversx_sdk_cli/testnet/config.py
+++ b/multiversx_sdk_cli/testnet/config.py
@@ -99,14 +99,8 @@ class TestnetConfiguration:
         """
 
         local_config = cls.get_local_config(filename)
-        sdk_testnet_config = cls.get_sdk_testnet_config()
-        final_config = merge_configs(sdk_testnet_config, local_config)
+        final_config = merge_configs(cls.default(), local_config)
         return cls(final_config)
-
-    @classmethod
-    def from_sdk_testnet_config(cls):
-        config = cls.get_sdk_testnet_config()
-        return cls(config)
 
     @classmethod
     def from_default_config(cls):
@@ -120,18 +114,6 @@ class TestnetConfiguration:
                 return dict()
 
         return utils.read_toml_file(filename)
-
-    @classmethod
-    def get_sdk_testnet_config(cls):
-        default = cls.default()
-        filename = workstation.get_tools_folder() / "testnet.toml"
-
-        if not filename.exists():
-            logger.info('writing sdk_testnet_config from defaults')
-            utils.write_toml_file(str(filename), default)
-            return default
-        sdk_testnet_config = utils.read_toml_file(filename)
-        return merge_configs(default, sdk_testnet_config)
 
     def node_config_source(self) -> Path:
         return self.node_source() / 'cmd' / 'node' / 'config'

--- a/mxpy-up.py
+++ b/mxpy-up.py
@@ -174,6 +174,10 @@ You may need to reinstall wasm-opt using `mxpy deps install wasm-opt`.
 
         shutil.rmtree(nodejs_folder)
 
+    global_testnet_toml = sdk_path / "testnet.toml"
+    if global_testnet_toml.exists():
+        global_testnet_toml.unlink()
+
 
 def create_venv():
     require_python_venv_tools()


### PR DESCRIPTION
 - Do not use a global `~/multiversx-sdk/testnet.toml`. 
 - Rely only on the hard-coded default configuration, plus the local `testnet.toml` overrides.
 - Reason: the global config file caused some confusion and issues in the past ([example](https://discord.com/channels/1045353153073258557/1067451587225718875/1067451587225718875)).