### PR TITLE
Remove command "mxpy account get-transactions"

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -857,16 +857,15 @@ usage: mxpy account COMMAND [-h] ...
 Get Account data (nonce, balance) from the Network
 
 COMMANDS:
-  {get,get-transactions}
+  {get}
 
 OPTIONS:
-  -h, --help            show this help message and exit
+  -h, --help  show this help message and exit
 
 ----------------
 COMMANDS summary
 ----------------
 get                            Query account details (nonce, balance etc.)
-get-transactions               Query account transactions
 
 ```
 ### Account.Get
@@ -888,22 +887,6 @@ optional arguments:
   --omit-fields OMIT_FIELDS  omit fields in the output payload (default: [])
 
 ```
-### Account.GetTransactions
-
-
-```
-$ mxpy account get-transactions --help
-usage: mxpy account get-transactions [-h] ...
-
-Query account transactions
-
-optional arguments:
-  -h, --help         show this help message and exit
-  --proxy PROXY      🔗 the URL of the proxy (default: https://testnet-gateway.multiversx.com)
-  --outfile OUTFILE  where to save the output (default: stdout)
-  --address ADDRESS  🖄 the address to query
-
-```
 ## Group **Wallet**
 
 
@@ -914,7 +897,7 @@ usage: mxpy wallet COMMAND [-h] ...
 Create wallet, derive secret key from mnemonic, bech32 address helpers etc.
 
 COMMANDS:
-  {new,derive,convert,bech32,pem-address,pem-address-hex}
+  {new,convert,bech32,pem-address,pem-address-hex}
 
 OPTIONS:
   -h, --help            show this help message and exit
@@ -948,7 +931,6 @@ optional arguments:
                                                   secret-key or pem (default: erd)
 
 ```
-
 ### Wallet.Convert
 
 

--- a/CLI.md.sh
+++ b/CLI.md.sh
@@ -68,7 +68,6 @@ generate() {
 
     group "Account" "account"
     command "Account.Get" "account get"
-    command "Account.GetTransactions" "account get-transactions"
 
     group "Wallet" "wallet"
     command "Wallet.New" "wallet new"

--- a/multiversx_sdk_cli/cli_accounts.py
+++ b/multiversx_sdk_cli/cli_accounts.py
@@ -1,9 +1,11 @@
 import logging
 from typing import Any
 
+from multiversx_sdk_network_providers.proxy_network_provider import \
+    ProxyNetworkProvider
+
 from multiversx_sdk_cli import cli_shared, utils
 from multiversx_sdk_cli.accounts import Address
-from multiversx_sdk_network_providers.proxy_network_provider import ProxyNetworkProvider
 
 logger = logging.getLogger("cli.accounts")
 
@@ -21,12 +23,6 @@ def setup_parser(subparsers: Any) -> Any:
     mutex.add_argument("--username", action="store_true", help="whether to only fetch the username")
     cli_shared.add_omit_fields_arg(sub)
     sub.set_defaults(func=get_account)
-
-    sub = cli_shared.add_command_subparser(subparsers, "account", "get-transactions", "Query account transactions")
-    cli_shared.add_proxy_arg(sub)
-    cli_shared.add_outfile_arg(sub)
-    _add_address_arg(sub)
-    sub.set_defaults(func=get_account_transactions)
 
     parser.epilog = cli_shared.build_group_epilog(subparsers)
     return subparsers
@@ -50,13 +46,3 @@ def get_account(args: Any):
         print(account.username)
     else:
         utils.dump_out_json(account.to_dictionary())
-
-
-def get_account_transactions(args: Any):
-    proxy_url = args.proxy
-    address = args.address
-    proxy = ProxyNetworkProvider(proxy_url)
-
-    response = proxy.get_account_transactions(Address(address))
-    transactions_as_dictionaries = [tx.to_dictionary() for tx in response]
-    utils.dump_out_json(transactions_as_dictionaries, args.outfile)

--- a/multiversx_sdk_cli/tests/test_proxy.py
+++ b/multiversx_sdk_cli/tests/test_proxy.py
@@ -1,23 +1,8 @@
-from pathlib import Path
-from multiversx_sdk_cli.cli import main
+from multiversx_sdk_network_providers.proxy_network_provider import \
+    ProxyNetworkProvider
+
 from multiversx_sdk_cli.accounts import Account
-from multiversx_sdk_network_providers.proxy_network_provider import ProxyNetworkProvider
-
-
-def test_get_transactions():
-    output_file = Path(__file__).parent / "testdata-out" / "transactions.txt"
-
-    main(
-        [
-            "account",
-            "get-transactions",
-            "--address",
-            "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th",
-            "--outfile",
-            str(output_file),
-        ]
-    )
-    assert Path.is_file(output_file) == True
+from multiversx_sdk_cli.cli import main
 
 
 def test_get_account():


### PR DESCRIPTION
Removed command `mxpy account get-transactions`, without a prior deprecation notice (being very exotic, rarely used, and not very helpful). Instead, one can directly query the API using `wget` or `curl`.