### PR TITLE
Update references (sdk-wallet)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "multiversx-sdk-cli"
-version = "6.2.1"
+version = "6.3.0"
 authors = [
   { name="MultiversX" },
 ]
@@ -26,7 +26,7 @@ dependencies = [
   "semver",
   "requests-cache",
   "multiversx-sdk-network-providers==0.6.*",
-  "multiversx-sdk-wallet==0.6.*",
+  "multiversx-sdk-wallet==0.7.*",
   "multiversx-sdk-core>=0.4.1"
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ requests-cache
 
 multiversx-sdk-core>=0.4.1
 multiversx-sdk-network-providers==0.6.*
-multiversx-sdk-wallet==0.6.*
+multiversx-sdk-wallet==0.7.*


### PR DESCRIPTION
Commands such as `mxpy validator stake` should now work on MacOS with M1 / M2, as well. Tested on an M2 machine.

Should fix https://github.com/multiversx/mx-sdk-py-cli/issues/260.