### PR TITLE
Allow transaction signing with guardian key

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -193,40 +193,54 @@ Output example:
 }
 
 optional arguments:
-  -h, --help                                   show this help message and exit
-  --project PROJECT                            🗀 the project directory (default: current directory)
-  --bytecode BYTECODE                          the file containing the WASM bytecode
-  --metadata-not-upgradeable                   ‼ mark the contract as NOT upgradeable (default: upgradeable)
-  --metadata-not-readable                      ‼ mark the contract as NOT readable (default: readable)
-  --metadata-payable                           ‼ mark the contract as payable (default: not payable)
-  --metadata-payable-by-sc                     ‼ mark the contract as payable by SC (default: not payable by SC)
-  --outfile OUTFILE                            where to save the output (default: stdout)
-  --pem PEM                                    🔑 the PEM file, if keyfile not provided
-  --pem-index PEM_INDEX                        🔑 the index in the PEM file (default: 0)
-  --keyfile KEYFILE                            🔑 a JSON keyfile, if PEM not provided
-  --passfile PASSFILE                          🔑 a file containing keyfile's password, if keyfile provided
-  --ledger                                     🔐 bool flag for signing transaction using ledger
-  --ledger-account-index LEDGER_ACCOUNT_INDEX  🔐 the index of the account when using Ledger
-  --ledger-address-index LEDGER_ADDRESS_INDEX  🔐 the index of the address when using Ledger
-  --sender-username SENDER_USERNAME            🖄 the username of the sender
-  --proxy PROXY                                🔗 the URL of the proxy (default: https://testnet-gateway.multiversx.com)
-  --nonce NONCE                                # the nonce for the transaction
-  --recall-nonce                               ⭮ whether to recall the nonce when creating the transaction (default:
-                                               False)
-  --gas-price GAS_PRICE                        ⛽ the gas price (default: 1000000000)
-  --gas-limit GAS_LIMIT                        ⛽ the gas limit
-  --value VALUE                                the value to transfer (default: 0)
-  --chain CHAIN                                the chain identifier (default: T)
-  --version VERSION                            the transaction version (default: 1)
-  --options OPTIONS                            the transaction options (default: 0)
-  --arguments ARGUMENTS [ARGUMENTS ...]        arguments for the contract transaction, as [number, bech32-address, ascii
-                                               string, boolean] or hex-encoded. E.g. --arguments 42 0x64 1000 0xabba
-                                               str:TOK-a1c2ef true erd1[..]
-  --wait-result                                signal to wait for the transaction result - only valid if --send is set
-  --timeout TIMEOUT                            max num of seconds to wait for result - only valid if --wait-result is
-                                               set
-  --send                                       ✓ whether to broadcast the transaction (default: False)
-  --simulate                                   whether to simulate the transaction (default: False)
+  -h, --help                                      show this help message and exit
+  --project PROJECT                               🗀 the project directory (default: current directory)
+  --bytecode BYTECODE                             the file containing the WASM bytecode
+  --metadata-not-upgradeable                      ‼ mark the contract as NOT upgradeable (default: upgradeable)
+  --metadata-not-readable                         ‼ mark the contract as NOT readable (default: readable)
+  --metadata-payable                              ‼ mark the contract as payable (default: not payable)
+  --metadata-payable-by-sc                        ‼ mark the contract as payable by SC (default: not payable by SC)
+  --outfile OUTFILE                               where to save the output (default: stdout)
+  --pem PEM                                       🔑 the PEM file, if keyfile not provided
+  --pem-index PEM_INDEX                           🔑 the index in the PEM file (default: 0)
+  --keyfile KEYFILE                               🔑 a JSON keyfile, if PEM not provided
+  --passfile PASSFILE                             🔑 a file containing keyfile's password, if keyfile provided
+  --ledger                                        🔐 bool flag for signing transaction using ledger
+  --ledger-account-index LEDGER_ACCOUNT_INDEX     🔐 the index of the account when using Ledger
+  --ledger-address-index LEDGER_ADDRESS_INDEX     🔐 the index of the address when using Ledger
+  --sender-username SENDER_USERNAME               🖄 the username of the sender
+  --proxy PROXY                                   🔗 the URL of the proxy (default: https://testnet-
+                                                  gateway.multiversx.com)
+  --nonce NONCE                                   # the nonce for the transaction
+  --recall-nonce                                  ⭮ whether to recall the nonce when creating the transaction (default:
+                                                  False)
+  --gas-price GAS_PRICE                           ⛽ the gas price (default: 1000000000)
+  --gas-limit GAS_LIMIT                           ⛽ the gas limit
+  --value VALUE                                   the value to transfer (default: 0)
+  --chain CHAIN                                   the chain identifier (default: T)
+  --version VERSION                               the transaction version (default: 2)
+  --guardian GUARDIAN                             the address of the guradian
+  --guardian-service-url GUARDIAN_SERVICE_URL     the url of the guardian service
+  --guardian-2fa-code GUARDIAN_2FA_CODE           the 2fa code for the guardian
+  --options OPTIONS                               the transaction options (default: 0)
+  --arguments ARGUMENTS [ARGUMENTS ...]           arguments for the contract transaction, as [number, bech32-address,
+                                                  ascii string, boolean] or hex-encoded. E.g. --arguments 42 0x64 1000
+                                                  0xabba str:TOK-a1c2ef true erd1[..]
+  --wait-result                                   signal to wait for the transaction result - only valid if --send is
+                                                  set
+  --timeout TIMEOUT                               max num of seconds to wait for result - only valid if --wait-result is
+                                                  set
+  --send                                          ✓ whether to broadcast the transaction (default: False)
+  --simulate                                      whether to simulate the transaction (default: False)
+  --guardian-pem GUARDIAN_PEM                     🔑 the PEM file, if keyfile not provided
+  --guardian-pem-index GUARDIAN_PEM_INDEX         🔑 the index in the PEM file (default: 0)
+  --guardian-keyfile GUARDIAN_KEYFILE             🔑 a JSON keyfile, if PEM not provided
+  --guardian-passfile GUARDIAN_PASSFILE           🔑 a file containing keyfile's password, if keyfile provided
+  --guardian-ledger                               🔐 bool flag for signing transaction using ledger
+  --guardian-ledger-account-index GUARDIAN_LEDGER_ACCOUNT_INDEX
+                                                  🔐 the index of the account when using Ledger
+  --guardian-ledger-address-index GUARDIAN_LEDGER_ADDRESS_INDEX
+                                                  🔐 the index of the address when using Ledger
 
 ```
 ### Contract.Call
@@ -267,39 +281,53 @@ Output example:
 }
 
 positional arguments:
-  contract                                     🖄 the address of the Smart Contract
+  contract                                        🖄 the address of the Smart Contract
 
 optional arguments:
-  -h, --help                                   show this help message and exit
-  --outfile OUTFILE                            where to save the output (default: stdout)
-  --pem PEM                                    🔑 the PEM file, if keyfile not provided
-  --pem-index PEM_INDEX                        🔑 the index in the PEM file (default: 0)
-  --keyfile KEYFILE                            🔑 a JSON keyfile, if PEM not provided
-  --passfile PASSFILE                          🔑 a file containing keyfile's password, if keyfile provided
-  --ledger                                     🔐 bool flag for signing transaction using ledger
-  --ledger-account-index LEDGER_ACCOUNT_INDEX  🔐 the index of the account when using Ledger
-  --ledger-address-index LEDGER_ADDRESS_INDEX  🔐 the index of the address when using Ledger
-  --sender-username SENDER_USERNAME            🖄 the username of the sender
-  --proxy PROXY                                🔗 the URL of the proxy (default: https://testnet-gateway.multiversx.com)
-  --nonce NONCE                                # the nonce for the transaction
-  --recall-nonce                               ⭮ whether to recall the nonce when creating the transaction (default:
-                                               False)
-  --gas-price GAS_PRICE                        ⛽ the gas price (default: 1000000000)
-  --gas-limit GAS_LIMIT                        ⛽ the gas limit
-  --value VALUE                                the value to transfer (default: 0)
-  --chain CHAIN                                the chain identifier (default: T)
-  --version VERSION                            the transaction version (default: 1)
-  --options OPTIONS                            the transaction options (default: 0)
-  --function FUNCTION                          the function to call
-  --arguments ARGUMENTS [ARGUMENTS ...]        arguments for the contract transaction, as [number, bech32-address, ascii
-                                               string, boolean] or hex-encoded. E.g. --arguments 42 0x64 1000 0xabba
-                                               str:TOK-a1c2ef true erd1[..]
-  --wait-result                                signal to wait for the transaction result - only valid if --send is set
-  --timeout TIMEOUT                            max num of seconds to wait for result - only valid if --wait-result is
-                                               set
-  --send                                       ✓ whether to broadcast the transaction (default: False)
-  --simulate                                   whether to simulate the transaction (default: False)
-  --relay                                      whether to relay the transaction (default: False)
+  -h, --help                                      show this help message and exit
+  --outfile OUTFILE                               where to save the output (default: stdout)
+  --pem PEM                                       🔑 the PEM file, if keyfile not provided
+  --pem-index PEM_INDEX                           🔑 the index in the PEM file (default: 0)
+  --keyfile KEYFILE                               🔑 a JSON keyfile, if PEM not provided
+  --passfile PASSFILE                             🔑 a file containing keyfile's password, if keyfile provided
+  --ledger                                        🔐 bool flag for signing transaction using ledger
+  --ledger-account-index LEDGER_ACCOUNT_INDEX     🔐 the index of the account when using Ledger
+  --ledger-address-index LEDGER_ADDRESS_INDEX     🔐 the index of the address when using Ledger
+  --sender-username SENDER_USERNAME               🖄 the username of the sender
+  --proxy PROXY                                   🔗 the URL of the proxy (default: https://testnet-
+                                                  gateway.multiversx.com)
+  --nonce NONCE                                   # the nonce for the transaction
+  --recall-nonce                                  ⭮ whether to recall the nonce when creating the transaction (default:
+                                                  False)
+  --gas-price GAS_PRICE                           ⛽ the gas price (default: 1000000000)
+  --gas-limit GAS_LIMIT                           ⛽ the gas limit
+  --value VALUE                                   the value to transfer (default: 0)
+  --chain CHAIN                                   the chain identifier (default: T)
+  --version VERSION                               the transaction version (default: 2)
+  --guardian GUARDIAN                             the address of the guradian
+  --guardian-service-url GUARDIAN_SERVICE_URL     the url of the guardian service
+  --guardian-2fa-code GUARDIAN_2FA_CODE           the 2fa code for the guardian
+  --options OPTIONS                               the transaction options (default: 0)
+  --function FUNCTION                             the function to call
+  --arguments ARGUMENTS [ARGUMENTS ...]           arguments for the contract transaction, as [number, bech32-address,
+                                                  ascii string, boolean] or hex-encoded. E.g. --arguments 42 0x64 1000
+                                                  0xabba str:TOK-a1c2ef true erd1[..]
+  --wait-result                                   signal to wait for the transaction result - only valid if --send is
+                                                  set
+  --timeout TIMEOUT                               max num of seconds to wait for result - only valid if --wait-result is
+                                                  set
+  --send                                          ✓ whether to broadcast the transaction (default: False)
+  --simulate                                      whether to simulate the transaction (default: False)
+  --relay                                         whether to relay the transaction (default: False)
+  --guardian-pem GUARDIAN_PEM                     🔑 the PEM file, if keyfile not provided
+  --guardian-pem-index GUARDIAN_PEM_INDEX         🔑 the index in the PEM file (default: 0)
+  --guardian-keyfile GUARDIAN_KEYFILE             🔑 a JSON keyfile, if PEM not provided
+  --guardian-passfile GUARDIAN_PASSFILE           🔑 a file containing keyfile's password, if keyfile provided
+  --guardian-ledger                               🔐 bool flag for signing transaction using ledger
+  --guardian-ledger-account-index GUARDIAN_LEDGER_ACCOUNT_INDEX
+                                                  🔐 the index of the account when using Ledger
+  --guardian-ledger-address-index GUARDIAN_LEDGER_ADDRESS_INDEX
+                                                  🔐 the index of the address when using Ledger
 
 ```
 ### Contract.Upgrade
@@ -340,43 +368,57 @@ Output example:
 }
 
 positional arguments:
-  contract                                     🖄 the address of the Smart Contract
+  contract                                        🖄 the address of the Smart Contract
 
 optional arguments:
-  -h, --help                                   show this help message and exit
-  --outfile OUTFILE                            where to save the output (default: stdout)
-  --project PROJECT                            🗀 the project directory (default: current directory)
-  --bytecode BYTECODE                          the file containing the WASM bytecode
-  --metadata-not-upgradeable                   ‼ mark the contract as NOT upgradeable (default: upgradeable)
-  --metadata-not-readable                      ‼ mark the contract as NOT readable (default: readable)
-  --metadata-payable                           ‼ mark the contract as payable (default: not payable)
-  --metadata-payable-by-sc                     ‼ mark the contract as payable by SC (default: not payable by SC)
-  --pem PEM                                    🔑 the PEM file, if keyfile not provided
-  --pem-index PEM_INDEX                        🔑 the index in the PEM file (default: 0)
-  --keyfile KEYFILE                            🔑 a JSON keyfile, if PEM not provided
-  --passfile PASSFILE                          🔑 a file containing keyfile's password, if keyfile provided
-  --ledger                                     🔐 bool flag for signing transaction using ledger
-  --ledger-account-index LEDGER_ACCOUNT_INDEX  🔐 the index of the account when using Ledger
-  --ledger-address-index LEDGER_ADDRESS_INDEX  🔐 the index of the address when using Ledger
-  --sender-username SENDER_USERNAME            🖄 the username of the sender
-  --proxy PROXY                                🔗 the URL of the proxy (default: https://testnet-gateway.multiversx.com)
-  --nonce NONCE                                # the nonce for the transaction
-  --recall-nonce                               ⭮ whether to recall the nonce when creating the transaction (default:
-                                               False)
-  --gas-price GAS_PRICE                        ⛽ the gas price (default: 1000000000)
-  --gas-limit GAS_LIMIT                        ⛽ the gas limit
-  --value VALUE                                the value to transfer (default: 0)
-  --chain CHAIN                                the chain identifier (default: T)
-  --version VERSION                            the transaction version (default: 1)
-  --options OPTIONS                            the transaction options (default: 0)
-  --arguments ARGUMENTS [ARGUMENTS ...]        arguments for the contract transaction, as [number, bech32-address, ascii
-                                               string, boolean] or hex-encoded. E.g. --arguments 42 0x64 1000 0xabba
-                                               str:TOK-a1c2ef true erd1[..]
-  --wait-result                                signal to wait for the transaction result - only valid if --send is set
-  --timeout TIMEOUT                            max num of seconds to wait for result - only valid if --wait-result is
-                                               set
-  --send                                       ✓ whether to broadcast the transaction (default: False)
-  --simulate                                   whether to simulate the transaction (default: False)
+  -h, --help                                      show this help message and exit
+  --outfile OUTFILE                               where to save the output (default: stdout)
+  --project PROJECT                               🗀 the project directory (default: current directory)
+  --bytecode BYTECODE                             the file containing the WASM bytecode
+  --metadata-not-upgradeable                      ‼ mark the contract as NOT upgradeable (default: upgradeable)
+  --metadata-not-readable                         ‼ mark the contract as NOT readable (default: readable)
+  --metadata-payable                              ‼ mark the contract as payable (default: not payable)
+  --metadata-payable-by-sc                        ‼ mark the contract as payable by SC (default: not payable by SC)
+  --pem PEM                                       🔑 the PEM file, if keyfile not provided
+  --pem-index PEM_INDEX                           🔑 the index in the PEM file (default: 0)
+  --keyfile KEYFILE                               🔑 a JSON keyfile, if PEM not provided
+  --passfile PASSFILE                             🔑 a file containing keyfile's password, if keyfile provided
+  --ledger                                        🔐 bool flag for signing transaction using ledger
+  --ledger-account-index LEDGER_ACCOUNT_INDEX     🔐 the index of the account when using Ledger
+  --ledger-address-index LEDGER_ADDRESS_INDEX     🔐 the index of the address when using Ledger
+  --sender-username SENDER_USERNAME               🖄 the username of the sender
+  --proxy PROXY                                   🔗 the URL of the proxy (default: https://testnet-
+                                                  gateway.multiversx.com)
+  --nonce NONCE                                   # the nonce for the transaction
+  --recall-nonce                                  ⭮ whether to recall the nonce when creating the transaction (default:
+                                                  False)
+  --gas-price GAS_PRICE                           ⛽ the gas price (default: 1000000000)
+  --gas-limit GAS_LIMIT                           ⛽ the gas limit
+  --value VALUE                                   the value to transfer (default: 0)
+  --chain CHAIN                                   the chain identifier (default: T)
+  --version VERSION                               the transaction version (default: 2)
+  --guardian GUARDIAN                             the address of the guradian
+  --guardian-service-url GUARDIAN_SERVICE_URL     the url of the guardian service
+  --guardian-2fa-code GUARDIAN_2FA_CODE           the 2fa code for the guardian
+  --options OPTIONS                               the transaction options (default: 0)
+  --arguments ARGUMENTS [ARGUMENTS ...]           arguments for the contract transaction, as [number, bech32-address,
+                                                  ascii string, boolean] or hex-encoded. E.g. --arguments 42 0x64 1000
+                                                  0xabba str:TOK-a1c2ef true erd1[..]
+  --wait-result                                   signal to wait for the transaction result - only valid if --send is
+                                                  set
+  --timeout TIMEOUT                               max num of seconds to wait for result - only valid if --wait-result is
+                                                  set
+  --send                                          ✓ whether to broadcast the transaction (default: False)
+  --simulate                                      whether to simulate the transaction (default: False)
+  --guardian-pem GUARDIAN_PEM                     🔑 the PEM file, if keyfile not provided
+  --guardian-pem-index GUARDIAN_PEM_INDEX         🔑 the index in the PEM file (default: 0)
+  --guardian-keyfile GUARDIAN_KEYFILE             🔑 a JSON keyfile, if PEM not provided
+  --guardian-passfile GUARDIAN_PASSFILE           🔑 a file containing keyfile's password, if keyfile provided
+  --guardian-ledger                               🔐 bool flag for signing transaction using ledger
+  --guardian-ledger-account-index GUARDIAN_LEDGER_ACCOUNT_INDEX
+                                                  🔐 the index of the account when using Ledger
+  --guardian-ledger-address-index GUARDIAN_LEDGER_ADDRESS_INDEX
+                                                  🔐 the index of the address when using Ledger
 
 ```
 ### Contract.Query
@@ -447,10 +489,10 @@ usage: mxpy tx COMMAND [-h] ...
 Create and broadcast Transactions
 
 COMMANDS:
-  {new,send,get}
+  {new,send,get,sign}
 
 OPTIONS:
-  -h, --help      show this help message and exit
+  -h, --help           show this help message and exit
 
 ----------------
 COMMANDS summary
@@ -458,6 +500,7 @@ COMMANDS summary
 new                            Create a new transaction.
 send                           Send a previously saved transaction.
 get                            Get a transaction.
+sign                           Sign a previously saved transaction.
 
 ```
 ### Transactions.New
@@ -483,36 +526,50 @@ Output example:
 }
 
 optional arguments:
-  -h, --help                                   show this help message and exit
-  --pem PEM                                    🔑 the PEM file, if keyfile not provided
-  --pem-index PEM_INDEX                        🔑 the index in the PEM file (default: 0)
-  --keyfile KEYFILE                            🔑 a JSON keyfile, if PEM not provided
-  --passfile PASSFILE                          🔑 a file containing keyfile's password, if keyfile provided
-  --ledger                                     🔐 bool flag for signing transaction using ledger
-  --ledger-account-index LEDGER_ACCOUNT_INDEX  🔐 the index of the account when using Ledger
-  --ledger-address-index LEDGER_ADDRESS_INDEX  🔐 the index of the address when using Ledger
-  --sender-username SENDER_USERNAME            🖄 the username of the sender
-  --nonce NONCE                                # the nonce for the transaction
-  --recall-nonce                               ⭮ whether to recall the nonce when creating the transaction (default:
-                                               False)
-  --receiver RECEIVER                          🖄 the address of the receiver
-  --receiver-username RECEIVER_USERNAME        🖄 the username of the receiver
-  --gas-price GAS_PRICE                        ⛽ the gas price (default: 1000000000)
-  --gas-limit GAS_LIMIT                        ⛽ the gas limit
-  --value VALUE                                the value to transfer (default: 0)
-  --data DATA                                  the payload, or 'memo' of the transaction (default: )
-  --chain CHAIN                                the chain identifier (default: T)
-  --version VERSION                            the transaction version (default: 1)
-  --options OPTIONS                            the transaction options (default: 0)
-  --data-file DATA_FILE                        a file containing transaction data
-  --outfile OUTFILE                            where to save the output (signed transaction, hash) (default: stdout)
-  --send                                       ✓ whether to broadcast the transaction (default: False)
-  --simulate                                   whether to simulate the transaction (default: False)
-  --relay                                      whether to relay the transaction (default: False)
-  --proxy PROXY                                🔗 the URL of the proxy (default: https://testnet-gateway.multiversx.com)
-  --wait-result                                signal to wait for the transaction result - only valid if --send is set
-  --timeout TIMEOUT                            max num of seconds to wait for result - only valid if --wait-result is
-                                               set
+  -h, --help                                      show this help message and exit
+  --pem PEM                                       🔑 the PEM file, if keyfile not provided
+  --pem-index PEM_INDEX                           🔑 the index in the PEM file (default: 0)
+  --keyfile KEYFILE                               🔑 a JSON keyfile, if PEM not provided
+  --passfile PASSFILE                             🔑 a file containing keyfile's password, if keyfile provided
+  --ledger                                        🔐 bool flag for signing transaction using ledger
+  --ledger-account-index LEDGER_ACCOUNT_INDEX     🔐 the index of the account when using Ledger
+  --ledger-address-index LEDGER_ADDRESS_INDEX     🔐 the index of the address when using Ledger
+  --sender-username SENDER_USERNAME               🖄 the username of the sender
+  --nonce NONCE                                   # the nonce for the transaction
+  --recall-nonce                                  ⭮ whether to recall the nonce when creating the transaction (default:
+                                                  False)
+  --receiver RECEIVER                             🖄 the address of the receiver
+  --receiver-username RECEIVER_USERNAME           🖄 the username of the receiver
+  --gas-price GAS_PRICE                           ⛽ the gas price (default: 1000000000)
+  --gas-limit GAS_LIMIT                           ⛽ the gas limit
+  --value VALUE                                   the value to transfer (default: 0)
+  --data DATA                                     the payload, or 'memo' of the transaction (default: )
+  --chain CHAIN                                   the chain identifier (default: T)
+  --version VERSION                               the transaction version (default: 2)
+  --guardian GUARDIAN                             the address of the guradian
+  --guardian-service-url GUARDIAN_SERVICE_URL     the url of the guardian service
+  --guardian-2fa-code GUARDIAN_2FA_CODE           the 2fa code for the guardian
+  --options OPTIONS                               the transaction options (default: 0)
+  --data-file DATA_FILE                           a file containing transaction data
+  --outfile OUTFILE                               where to save the output (signed transaction, hash) (default: stdout)
+  --send                                          ✓ whether to broadcast the transaction (default: False)
+  --simulate                                      whether to simulate the transaction (default: False)
+  --relay                                         whether to relay the transaction (default: False)
+  --proxy PROXY                                   🔗 the URL of the proxy (default: https://testnet-
+                                                  gateway.multiversx.com)
+  --guardian-pem GUARDIAN_PEM                     🔑 the PEM file, if keyfile not provided
+  --guardian-pem-index GUARDIAN_PEM_INDEX         🔑 the index in the PEM file (default: 0)
+  --guardian-keyfile GUARDIAN_KEYFILE             🔑 a JSON keyfile, if PEM not provided
+  --guardian-passfile GUARDIAN_PASSFILE           🔑 a file containing keyfile's password, if keyfile provided
+  --guardian-ledger                               🔐 bool flag for signing transaction using ledger
+  --guardian-ledger-account-index GUARDIAN_LEDGER_ACCOUNT_INDEX
+                                                  🔐 the index of the account when using Ledger
+  --guardian-ledger-address-index GUARDIAN_LEDGER_ADDRESS_INDEX
+                                                  🔐 the index of the address when using Ledger
+  --wait-result                                   signal to wait for the transaction result - only valid if --send is
+                                                  set
+  --timeout TIMEOUT                               max num of seconds to wait for result - only valid if --wait-result is
+                                                  set
 
 ```
 ### Transactions.Send
@@ -646,32 +703,45 @@ usage: mxpy validator stake [-h] ...
 Stake value into the Network
 
 optional arguments:
-  -h, --help                                   show this help message and exit
-  --proxy PROXY                                🔗 the URL of the proxy (default: https://testnet-gateway.multiversx.com)
-  --pem PEM                                    🔑 the PEM file, if keyfile not provided
-  --pem-index PEM_INDEX                        🔑 the index in the PEM file (default: 0)
-  --keyfile KEYFILE                            🔑 a JSON keyfile, if PEM not provided
-  --passfile PASSFILE                          🔑 a file containing keyfile's password, if keyfile provided
-  --ledger                                     🔐 bool flag for signing transaction using ledger
-  --ledger-account-index LEDGER_ACCOUNT_INDEX  🔐 the index of the account when using Ledger
-  --ledger-address-index LEDGER_ADDRESS_INDEX  🔐 the index of the address when using Ledger
-  --sender-username SENDER_USERNAME            🖄 the username of the sender
-  --nonce NONCE                                # the nonce for the transaction
-  --recall-nonce                               ⭮ whether to recall the nonce when creating the transaction (default:
-                                               False)
-  --gas-price GAS_PRICE                        ⛽ the gas price (default: 1000000000)
-  --gas-limit GAS_LIMIT                        ⛽ the gas limit
-  --estimate-gas                               ⛽ whether to estimate the gas limit (default: 0)
-  --value VALUE                                the value to transfer (default: 0)
-  --chain CHAIN                                the chain identifier (default: T)
-  --version VERSION                            the transaction version (default: 1)
-  --options OPTIONS                            the transaction options (default: 0)
-  --send                                       ✓ whether to broadcast the transaction (default: False)
-  --simulate                                   whether to simulate the transaction (default: False)
-  --outfile OUTFILE                            where to save the output (signed transaction, hash) (default: stdout)
-  --reward-address REWARD_ADDRESS              the reward address
-  --validators-file VALIDATORS_FILE            a JSON file describing the Nodes
-  --top-up                                     Stake value for top up
+  -h, --help                                      show this help message and exit
+  --proxy PROXY                                   🔗 the URL of the proxy (default: https://testnet-
+                                                  gateway.multiversx.com)
+  --pem PEM                                       🔑 the PEM file, if keyfile not provided
+  --pem-index PEM_INDEX                           🔑 the index in the PEM file (default: 0)
+  --keyfile KEYFILE                               🔑 a JSON keyfile, if PEM not provided
+  --passfile PASSFILE                             🔑 a file containing keyfile's password, if keyfile provided
+  --ledger                                        🔐 bool flag for signing transaction using ledger
+  --ledger-account-index LEDGER_ACCOUNT_INDEX     🔐 the index of the account when using Ledger
+  --ledger-address-index LEDGER_ADDRESS_INDEX     🔐 the index of the address when using Ledger
+  --sender-username SENDER_USERNAME               🖄 the username of the sender
+  --nonce NONCE                                   # the nonce for the transaction
+  --recall-nonce                                  ⭮ whether to recall the nonce when creating the transaction (default:
+                                                  False)
+  --gas-price GAS_PRICE                           ⛽ the gas price (default: 1000000000)
+  --gas-limit GAS_LIMIT                           ⛽ the gas limit
+  --estimate-gas                                  ⛽ whether to estimate the gas limit (default: 0)
+  --value VALUE                                   the value to transfer (default: 0)
+  --chain CHAIN                                   the chain identifier (default: T)
+  --version VERSION                               the transaction version (default: 2)
+  --guardian GUARDIAN                             the address of the guradian
+  --guardian-service-url GUARDIAN_SERVICE_URL     the url of the guardian service
+  --guardian-2fa-code GUARDIAN_2FA_CODE           the 2fa code for the guardian
+  --options OPTIONS                               the transaction options (default: 0)
+  --send                                          ✓ whether to broadcast the transaction (default: False)
+  --simulate                                      whether to simulate the transaction (default: False)
+  --outfile OUTFILE                               where to save the output (signed transaction, hash) (default: stdout)
+  --guardian-pem GUARDIAN_PEM                     🔑 the PEM file, if keyfile not provided
+  --guardian-pem-index GUARDIAN_PEM_INDEX         🔑 the index in the PEM file (default: 0)
+  --guardian-keyfile GUARDIAN_KEYFILE             🔑 a JSON keyfile, if PEM not provided
+  --guardian-passfile GUARDIAN_PASSFILE           🔑 a file containing keyfile's password, if keyfile provided
+  --guardian-ledger                               🔐 bool flag for signing transaction using ledger
+  --guardian-ledger-account-index GUARDIAN_LEDGER_ACCOUNT_INDEX
+                                                  🔐 the index of the account when using Ledger
+  --guardian-ledger-address-index GUARDIAN_LEDGER_ADDRESS_INDEX
+                                                  🔐 the index of the address when using Ledger
+  --reward-address REWARD_ADDRESS                 the reward address
+  --validators-file VALIDATORS_FILE               a JSON file describing the Nodes
+  --top-up                                        Stake value for top up
 
 ```
 ### Validator.Unstake
@@ -684,30 +754,43 @@ usage: mxpy validator unstake [-h] ...
 Unstake value
 
 optional arguments:
-  -h, --help                                   show this help message and exit
-  --proxy PROXY                                🔗 the URL of the proxy (default: https://testnet-gateway.multiversx.com)
-  --pem PEM                                    🔑 the PEM file, if keyfile not provided
-  --pem-index PEM_INDEX                        🔑 the index in the PEM file (default: 0)
-  --keyfile KEYFILE                            🔑 a JSON keyfile, if PEM not provided
-  --passfile PASSFILE                          🔑 a file containing keyfile's password, if keyfile provided
-  --ledger                                     🔐 bool flag for signing transaction using ledger
-  --ledger-account-index LEDGER_ACCOUNT_INDEX  🔐 the index of the account when using Ledger
-  --ledger-address-index LEDGER_ADDRESS_INDEX  🔐 the index of the address when using Ledger
-  --sender-username SENDER_USERNAME            🖄 the username of the sender
-  --nonce NONCE                                # the nonce for the transaction
-  --recall-nonce                               ⭮ whether to recall the nonce when creating the transaction (default:
-                                               False)
-  --gas-price GAS_PRICE                        ⛽ the gas price (default: 1000000000)
-  --gas-limit GAS_LIMIT                        ⛽ the gas limit
-  --estimate-gas                               ⛽ whether to estimate the gas limit (default: 0)
-  --value VALUE                                the value to transfer (default: 0)
-  --chain CHAIN                                the chain identifier (default: T)
-  --version VERSION                            the transaction version (default: 1)
-  --options OPTIONS                            the transaction options (default: 0)
-  --send                                       ✓ whether to broadcast the transaction (default: False)
-  --simulate                                   whether to simulate the transaction (default: False)
-  --outfile OUTFILE                            where to save the output (signed transaction, hash) (default: stdout)
-  --nodes-public-keys NODES_PUBLIC_KEYS        the public keys of the nodes as CSV (addrA,addrB)
+  -h, --help                                      show this help message and exit
+  --proxy PROXY                                   🔗 the URL of the proxy (default: https://testnet-
+                                                  gateway.multiversx.com)
+  --pem PEM                                       🔑 the PEM file, if keyfile not provided
+  --pem-index PEM_INDEX                           🔑 the index in the PEM file (default: 0)
+  --keyfile KEYFILE                               🔑 a JSON keyfile, if PEM not provided
+  --passfile PASSFILE                             🔑 a file containing keyfile's password, if keyfile provided
+  --ledger                                        🔐 bool flag for signing transaction using ledger
+  --ledger-account-index LEDGER_ACCOUNT_INDEX     🔐 the index of the account when using Ledger
+  --ledger-address-index LEDGER_ADDRESS_INDEX     🔐 the index of the address when using Ledger
+  --sender-username SENDER_USERNAME               🖄 the username of the sender
+  --nonce NONCE                                   # the nonce for the transaction
+  --recall-nonce                                  ⭮ whether to recall the nonce when creating the transaction (default:
+                                                  False)
+  --gas-price GAS_PRICE                           ⛽ the gas price (default: 1000000000)
+  --gas-limit GAS_LIMIT                           ⛽ the gas limit
+  --estimate-gas                                  ⛽ whether to estimate the gas limit (default: 0)
+  --value VALUE                                   the value to transfer (default: 0)
+  --chain CHAIN                                   the chain identifier (default: T)
+  --version VERSION                               the transaction version (default: 2)
+  --guardian GUARDIAN                             the address of the guradian
+  --guardian-service-url GUARDIAN_SERVICE_URL     the url of the guardian service
+  --guardian-2fa-code GUARDIAN_2FA_CODE           the 2fa code for the guardian
+  --options OPTIONS                               the transaction options (default: 0)
+  --send                                          ✓ whether to broadcast the transaction (default: False)
+  --simulate                                      whether to simulate the transaction (default: False)
+  --outfile OUTFILE                               where to save the output (signed transaction, hash) (default: stdout)
+  --guardian-pem GUARDIAN_PEM                     🔑 the PEM file, if keyfile not provided
+  --guardian-pem-index GUARDIAN_PEM_INDEX         🔑 the index in the PEM file (default: 0)
+  --guardian-keyfile GUARDIAN_KEYFILE             🔑 a JSON keyfile, if PEM not provided
+  --guardian-passfile GUARDIAN_PASSFILE           🔑 a file containing keyfile's password, if keyfile provided
+  --guardian-ledger                               🔐 bool flag for signing transaction using ledger
+  --guardian-ledger-account-index GUARDIAN_LEDGER_ACCOUNT_INDEX
+                                                  🔐 the index of the account when using Ledger
+  --guardian-ledger-address-index GUARDIAN_LEDGER_ADDRESS_INDEX
+                                                  🔐 the index of the address when using Ledger
+  --nodes-public-keys NODES_PUBLIC_KEYS           the public keys of the nodes as CSV (addrA,addrB)
 
 ```
 ### Validator.Unjail
@@ -720,30 +803,43 @@ usage: mxpy validator unjail [-h] ...
 Unjail a Validator Node
 
 optional arguments:
-  -h, --help                                   show this help message and exit
-  --proxy PROXY                                🔗 the URL of the proxy (default: https://testnet-gateway.multiversx.com)
-  --pem PEM                                    🔑 the PEM file, if keyfile not provided
-  --pem-index PEM_INDEX                        🔑 the index in the PEM file (default: 0)
-  --keyfile KEYFILE                            🔑 a JSON keyfile, if PEM not provided
-  --passfile PASSFILE                          🔑 a file containing keyfile's password, if keyfile provided
-  --ledger                                     🔐 bool flag for signing transaction using ledger
-  --ledger-account-index LEDGER_ACCOUNT_INDEX  🔐 the index of the account when using Ledger
-  --ledger-address-index LEDGER_ADDRESS_INDEX  🔐 the index of the address when using Ledger
-  --sender-username SENDER_USERNAME            🖄 the username of the sender
-  --nonce NONCE                                # the nonce for the transaction
-  --recall-nonce                               ⭮ whether to recall the nonce when creating the transaction (default:
-                                               False)
-  --gas-price GAS_PRICE                        ⛽ the gas price (default: 1000000000)
-  --gas-limit GAS_LIMIT                        ⛽ the gas limit
-  --estimate-gas                               ⛽ whether to estimate the gas limit (default: 0)
-  --value VALUE                                the value to transfer (default: 0)
-  --chain CHAIN                                the chain identifier (default: T)
-  --version VERSION                            the transaction version (default: 1)
-  --options OPTIONS                            the transaction options (default: 0)
-  --send                                       ✓ whether to broadcast the transaction (default: False)
-  --simulate                                   whether to simulate the transaction (default: False)
-  --outfile OUTFILE                            where to save the output (signed transaction, hash) (default: stdout)
-  --nodes-public-keys NODES_PUBLIC_KEYS        the public keys of the nodes as CSV (addrA,addrB)
+  -h, --help                                      show this help message and exit
+  --proxy PROXY                                   🔗 the URL of the proxy (default: https://testnet-
+                                                  gateway.multiversx.com)
+  --pem PEM                                       🔑 the PEM file, if keyfile not provided
+  --pem-index PEM_INDEX                           🔑 the index in the PEM file (default: 0)
+  --keyfile KEYFILE                               🔑 a JSON keyfile, if PEM not provided
+  --passfile PASSFILE                             🔑 a file containing keyfile's password, if keyfile provided
+  --ledger                                        🔐 bool flag for signing transaction using ledger
+  --ledger-account-index LEDGER_ACCOUNT_INDEX     🔐 the index of the account when using Ledger
+  --ledger-address-index LEDGER_ADDRESS_INDEX     🔐 the index of the address when using Ledger
+  --sender-username SENDER_USERNAME               🖄 the username of the sender
+  --nonce NONCE                                   # the nonce for the transaction
+  --recall-nonce                                  ⭮ whether to recall the nonce when creating the transaction (default:
+                                                  False)
+  --gas-price GAS_PRICE                           ⛽ the gas price (default: 1000000000)
+  --gas-limit GAS_LIMIT                           ⛽ the gas limit
+  --estimate-gas                                  ⛽ whether to estimate the gas limit (default: 0)
+  --value VALUE                                   the value to transfer (default: 0)
+  --chain CHAIN                                   the chain identifier (default: T)
+  --version VERSION                               the transaction version (default: 2)
+  --guardian GUARDIAN                             the address of the guradian
+  --guardian-service-url GUARDIAN_SERVICE_URL     the url of the guardian service
+  --guardian-2fa-code GUARDIAN_2FA_CODE           the 2fa code for the guardian
+  --options OPTIONS                               the transaction options (default: 0)
+  --send                                          ✓ whether to broadcast the transaction (default: False)
+  --simulate                                      whether to simulate the transaction (default: False)
+  --outfile OUTFILE                               where to save the output (signed transaction, hash) (default: stdout)
+  --guardian-pem GUARDIAN_PEM                     🔑 the PEM file, if keyfile not provided
+  --guardian-pem-index GUARDIAN_PEM_INDEX         🔑 the index in the PEM file (default: 0)
+  --guardian-keyfile GUARDIAN_KEYFILE             🔑 a JSON keyfile, if PEM not provided
+  --guardian-passfile GUARDIAN_PASSFILE           🔑 a file containing keyfile's password, if keyfile provided
+  --guardian-ledger                               🔐 bool flag for signing transaction using ledger
+  --guardian-ledger-account-index GUARDIAN_LEDGER_ACCOUNT_INDEX
+                                                  🔐 the index of the account when using Ledger
+  --guardian-ledger-address-index GUARDIAN_LEDGER_ADDRESS_INDEX
+                                                  🔐 the index of the address when using Ledger
+  --nodes-public-keys NODES_PUBLIC_KEYS           the public keys of the nodes as CSV (addrA,addrB)
 
 ```
 ### Validator.Unbond
@@ -756,30 +852,43 @@ usage: mxpy validator unbond [-h] ...
 Unbond tokens for a bls key
 
 optional arguments:
-  -h, --help                                   show this help message and exit
-  --proxy PROXY                                🔗 the URL of the proxy (default: https://testnet-gateway.multiversx.com)
-  --pem PEM                                    🔑 the PEM file, if keyfile not provided
-  --pem-index PEM_INDEX                        🔑 the index in the PEM file (default: 0)
-  --keyfile KEYFILE                            🔑 a JSON keyfile, if PEM not provided
-  --passfile PASSFILE                          🔑 a file containing keyfile's password, if keyfile provided
-  --ledger                                     🔐 bool flag for signing transaction using ledger
-  --ledger-account-index LEDGER_ACCOUNT_INDEX  🔐 the index of the account when using Ledger
-  --ledger-address-index LEDGER_ADDRESS_INDEX  🔐 the index of the address when using Ledger
-  --sender-username SENDER_USERNAME            🖄 the username of the sender
-  --nonce NONCE                                # the nonce for the transaction
-  --recall-nonce                               ⭮ whether to recall the nonce when creating the transaction (default:
-                                               False)
-  --gas-price GAS_PRICE                        ⛽ the gas price (default: 1000000000)
-  --gas-limit GAS_LIMIT                        ⛽ the gas limit
-  --estimate-gas                               ⛽ whether to estimate the gas limit (default: 0)
-  --value VALUE                                the value to transfer (default: 0)
-  --chain CHAIN                                the chain identifier (default: T)
-  --version VERSION                            the transaction version (default: 1)
-  --options OPTIONS                            the transaction options (default: 0)
-  --send                                       ✓ whether to broadcast the transaction (default: False)
-  --simulate                                   whether to simulate the transaction (default: False)
-  --outfile OUTFILE                            where to save the output (signed transaction, hash) (default: stdout)
-  --nodes-public-keys NODES_PUBLIC_KEYS        the public keys of the nodes as CSV (addrA,addrB)
+  -h, --help                                      show this help message and exit
+  --proxy PROXY                                   🔗 the URL of the proxy (default: https://testnet-
+                                                  gateway.multiversx.com)
+  --pem PEM                                       🔑 the PEM file, if keyfile not provided
+  --pem-index PEM_INDEX                           🔑 the index in the PEM file (default: 0)
+  --keyfile KEYFILE                               🔑 a JSON keyfile, if PEM not provided
+  --passfile PASSFILE                             🔑 a file containing keyfile's password, if keyfile provided
+  --ledger                                        🔐 bool flag for signing transaction using ledger
+  --ledger-account-index LEDGER_ACCOUNT_INDEX     🔐 the index of the account when using Ledger
+  --ledger-address-index LEDGER_ADDRESS_INDEX     🔐 the index of the address when using Ledger
+  --sender-username SENDER_USERNAME               🖄 the username of the sender
+  --nonce NONCE                                   # the nonce for the transaction
+  --recall-nonce                                  ⭮ whether to recall the nonce when creating the transaction (default:
+                                                  False)
+  --gas-price GAS_PRICE                           ⛽ the gas price (default: 1000000000)
+  --gas-limit GAS_LIMIT                           ⛽ the gas limit
+  --estimate-gas                                  ⛽ whether to estimate the gas limit (default: 0)
+  --value VALUE                                   the value to transfer (default: 0)
+  --chain CHAIN                                   the chain identifier (default: T)
+  --version VERSION                               the transaction version (default: 2)
+  --guardian GUARDIAN                             the address of the guradian
+  --guardian-service-url GUARDIAN_SERVICE_URL     the url of the guardian service
+  --guardian-2fa-code GUARDIAN_2FA_CODE           the 2fa code for the guardian
+  --options OPTIONS                               the transaction options (default: 0)
+  --send                                          ✓ whether to broadcast the transaction (default: False)
+  --simulate                                      whether to simulate the transaction (default: False)
+  --outfile OUTFILE                               where to save the output (signed transaction, hash) (default: stdout)
+  --guardian-pem GUARDIAN_PEM                     🔑 the PEM file, if keyfile not provided
+  --guardian-pem-index GUARDIAN_PEM_INDEX         🔑 the index in the PEM file (default: 0)
+  --guardian-keyfile GUARDIAN_KEYFILE             🔑 a JSON keyfile, if PEM not provided
+  --guardian-passfile GUARDIAN_PASSFILE           🔑 a file containing keyfile's password, if keyfile provided
+  --guardian-ledger                               🔐 bool flag for signing transaction using ledger
+  --guardian-ledger-account-index GUARDIAN_LEDGER_ACCOUNT_INDEX
+                                                  🔐 the index of the account when using Ledger
+  --guardian-ledger-address-index GUARDIAN_LEDGER_ADDRESS_INDEX
+                                                  🔐 the index of the address when using Ledger
+  --nodes-public-keys NODES_PUBLIC_KEYS           the public keys of the nodes as CSV (addrA,addrB)
 
 ```
 ### Validator.ChangeRewardAddress
@@ -792,30 +901,43 @@ usage: mxpy validator change-reward-address [-h] ...
 Change the reward address
 
 optional arguments:
-  -h, --help                                   show this help message and exit
-  --proxy PROXY                                🔗 the URL of the proxy (default: https://testnet-gateway.multiversx.com)
-  --pem PEM                                    🔑 the PEM file, if keyfile not provided
-  --pem-index PEM_INDEX                        🔑 the index in the PEM file (default: 0)
-  --keyfile KEYFILE                            🔑 a JSON keyfile, if PEM not provided
-  --passfile PASSFILE                          🔑 a file containing keyfile's password, if keyfile provided
-  --ledger                                     🔐 bool flag for signing transaction using ledger
-  --ledger-account-index LEDGER_ACCOUNT_INDEX  🔐 the index of the account when using Ledger
-  --ledger-address-index LEDGER_ADDRESS_INDEX  🔐 the index of the address when using Ledger
-  --sender-username SENDER_USERNAME            🖄 the username of the sender
-  --nonce NONCE                                # the nonce for the transaction
-  --recall-nonce                               ⭮ whether to recall the nonce when creating the transaction (default:
-                                               False)
-  --gas-price GAS_PRICE                        ⛽ the gas price (default: 1000000000)
-  --gas-limit GAS_LIMIT                        ⛽ the gas limit
-  --estimate-gas                               ⛽ whether to estimate the gas limit (default: 0)
-  --value VALUE                                the value to transfer (default: 0)
-  --chain CHAIN                                the chain identifier (default: T)
-  --version VERSION                            the transaction version (default: 1)
-  --options OPTIONS                            the transaction options (default: 0)
-  --send                                       ✓ whether to broadcast the transaction (default: False)
-  --simulate                                   whether to simulate the transaction (default: False)
-  --outfile OUTFILE                            where to save the output (signed transaction, hash) (default: stdout)
-  --reward-address REWARD_ADDRESS              the new reward address
+  -h, --help                                      show this help message and exit
+  --proxy PROXY                                   🔗 the URL of the proxy (default: https://testnet-
+                                                  gateway.multiversx.com)
+  --pem PEM                                       🔑 the PEM file, if keyfile not provided
+  --pem-index PEM_INDEX                           🔑 the index in the PEM file (default: 0)
+  --keyfile KEYFILE                               🔑 a JSON keyfile, if PEM not provided
+  --passfile PASSFILE                             🔑 a file containing keyfile's password, if keyfile provided
+  --ledger                                        🔐 bool flag for signing transaction using ledger
+  --ledger-account-index LEDGER_ACCOUNT_INDEX     🔐 the index of the account when using Ledger
+  --ledger-address-index LEDGER_ADDRESS_INDEX     🔐 the index of the address when using Ledger
+  --sender-username SENDER_USERNAME               🖄 the username of the sender
+  --nonce NONCE                                   # the nonce for the transaction
+  --recall-nonce                                  ⭮ whether to recall the nonce when creating the transaction (default:
+                                                  False)
+  --gas-price GAS_PRICE                           ⛽ the gas price (default: 1000000000)
+  --gas-limit GAS_LIMIT                           ⛽ the gas limit
+  --estimate-gas                                  ⛽ whether to estimate the gas limit (default: 0)
+  --value VALUE                                   the value to transfer (default: 0)
+  --chain CHAIN                                   the chain identifier (default: T)
+  --version VERSION                               the transaction version (default: 2)
+  --guardian GUARDIAN                             the address of the guradian
+  --guardian-service-url GUARDIAN_SERVICE_URL     the url of the guardian service
+  --guardian-2fa-code GUARDIAN_2FA_CODE           the 2fa code for the guardian
+  --options OPTIONS                               the transaction options (default: 0)
+  --send                                          ✓ whether to broadcast the transaction (default: False)
+  --simulate                                      whether to simulate the transaction (default: False)
+  --outfile OUTFILE                               where to save the output (signed transaction, hash) (default: stdout)
+  --guardian-pem GUARDIAN_PEM                     🔑 the PEM file, if keyfile not provided
+  --guardian-pem-index GUARDIAN_PEM_INDEX         🔑 the index in the PEM file (default: 0)
+  --guardian-keyfile GUARDIAN_KEYFILE             🔑 a JSON keyfile, if PEM not provided
+  --guardian-passfile GUARDIAN_PASSFILE           🔑 a file containing keyfile's password, if keyfile provided
+  --guardian-ledger                               🔐 bool flag for signing transaction using ledger
+  --guardian-ledger-account-index GUARDIAN_LEDGER_ACCOUNT_INDEX
+                                                  🔐 the index of the account when using Ledger
+  --guardian-ledger-address-index GUARDIAN_LEDGER_ADDRESS_INDEX
+                                                  🔐 the index of the address when using Ledger
+  --reward-address REWARD_ADDRESS                 the new reward address
 
 ```
 ### Validator.Claim
@@ -828,29 +950,42 @@ usage: mxpy validator claim [-h] ...
 Claim rewards
 
 optional arguments:
-  -h, --help                                   show this help message and exit
-  --proxy PROXY                                🔗 the URL of the proxy (default: https://testnet-gateway.multiversx.com)
-  --pem PEM                                    🔑 the PEM file, if keyfile not provided
-  --pem-index PEM_INDEX                        🔑 the index in the PEM file (default: 0)
-  --keyfile KEYFILE                            🔑 a JSON keyfile, if PEM not provided
-  --passfile PASSFILE                          🔑 a file containing keyfile's password, if keyfile provided
-  --ledger                                     🔐 bool flag for signing transaction using ledger
-  --ledger-account-index LEDGER_ACCOUNT_INDEX  🔐 the index of the account when using Ledger
-  --ledger-address-index LEDGER_ADDRESS_INDEX  🔐 the index of the address when using Ledger
-  --sender-username SENDER_USERNAME            🖄 the username of the sender
-  --nonce NONCE                                # the nonce for the transaction
-  --recall-nonce                               ⭮ whether to recall the nonce when creating the transaction (default:
-                                               False)
-  --gas-price GAS_PRICE                        ⛽ the gas price (default: 1000000000)
-  --gas-limit GAS_LIMIT                        ⛽ the gas limit
-  --estimate-gas                               ⛽ whether to estimate the gas limit (default: 0)
-  --value VALUE                                the value to transfer (default: 0)
-  --chain CHAIN                                the chain identifier (default: T)
-  --version VERSION                            the transaction version (default: 1)
-  --options OPTIONS                            the transaction options (default: 0)
-  --send                                       ✓ whether to broadcast the transaction (default: False)
-  --simulate                                   whether to simulate the transaction (default: False)
-  --outfile OUTFILE                            where to save the output (signed transaction, hash) (default: stdout)
+  -h, --help                                      show this help message and exit
+  --proxy PROXY                                   🔗 the URL of the proxy (default: https://testnet-
+                                                  gateway.multiversx.com)
+  --pem PEM                                       🔑 the PEM file, if keyfile not provided
+  --pem-index PEM_INDEX                           🔑 the index in the PEM file (default: 0)
+  --keyfile KEYFILE                               🔑 a JSON keyfile, if PEM not provided
+  --passfile PASSFILE                             🔑 a file containing keyfile's password, if keyfile provided
+  --ledger                                        🔐 bool flag for signing transaction using ledger
+  --ledger-account-index LEDGER_ACCOUNT_INDEX     🔐 the index of the account when using Ledger
+  --ledger-address-index LEDGER_ADDRESS_INDEX     🔐 the index of the address when using Ledger
+  --sender-username SENDER_USERNAME               🖄 the username of the sender
+  --nonce NONCE                                   # the nonce for the transaction
+  --recall-nonce                                  ⭮ whether to recall the nonce when creating the transaction (default:
+                                                  False)
+  --gas-price GAS_PRICE                           ⛽ the gas price (default: 1000000000)
+  --gas-limit GAS_LIMIT                           ⛽ the gas limit
+  --estimate-gas                                  ⛽ whether to estimate the gas limit (default: 0)
+  --value VALUE                                   the value to transfer (default: 0)
+  --chain CHAIN                                   the chain identifier (default: T)
+  --version VERSION                               the transaction version (default: 2)
+  --guardian GUARDIAN                             the address of the guradian
+  --guardian-service-url GUARDIAN_SERVICE_URL     the url of the guardian service
+  --guardian-2fa-code GUARDIAN_2FA_CODE           the 2fa code for the guardian
+  --options OPTIONS                               the transaction options (default: 0)
+  --send                                          ✓ whether to broadcast the transaction (default: False)
+  --simulate                                      whether to simulate the transaction (default: False)
+  --outfile OUTFILE                               where to save the output (signed transaction, hash) (default: stdout)
+  --guardian-pem GUARDIAN_PEM                     🔑 the PEM file, if keyfile not provided
+  --guardian-pem-index GUARDIAN_PEM_INDEX         🔑 the index in the PEM file (default: 0)
+  --guardian-keyfile GUARDIAN_KEYFILE             🔑 a JSON keyfile, if PEM not provided
+  --guardian-passfile GUARDIAN_PASSFILE           🔑 a file containing keyfile's password, if keyfile provided
+  --guardian-ledger                               🔐 bool flag for signing transaction using ledger
+  --guardian-ledger-account-index GUARDIAN_LEDGER_ACCOUNT_INDEX
+                                                  🔐 the index of the account when using Ledger
+  --guardian-ledger-address-index GUARDIAN_LEDGER_ADDRESS_INDEX
+                                                  🔐 the index of the address when using Ledger
 
 ```
 ## Group **Account**

--- a/multiversx_sdk_cli/cli_delegation.py
+++ b/multiversx_sdk_cli/cli_delegation.py
@@ -134,6 +134,7 @@ def _add_common_arguments(args: List[str], sub: Any):
     cli_shared.add_tx_args(args, sub, with_receiver=False, with_data=False, with_estimate_gas=True, with_guardian=True)
     cli_shared.add_broadcast_args(sub, relay=False)
     cli_shared.add_outfile_arg(sub, what="signed transaction, hash")
+    cli_shared.add_guardian_wallet_args(args, sub)
 
 
 def do_create_delegation_contract(args: Any):

--- a/multiversx_sdk_cli/cli_dns.py
+++ b/multiversx_sdk_cli/cli_dns.py
@@ -18,6 +18,7 @@ def setup_parser(args: List[str], subparsers: Any) -> Any:
     cli_shared.add_wallet_args(args, sub)
     cli_shared.add_proxy_arg(sub)
     cli_shared.add_tx_args(args, sub, with_receiver=False, with_data=False, with_guardian=True)
+    cli_shared.add_guardian_wallet_args(args, sub)
     sub.add_argument("--name", help="the name to register")
     sub.set_defaults(func=register)
 

--- a/multiversx_sdk_cli/cli_password.py
+++ b/multiversx_sdk_cli/cli_password.py
@@ -1,8 +1,16 @@
 from typing import Any
 from getpass import getpass
 
+
 def load_password(args: Any):
     if args.passfile:
         with open(args.passfile) as pass_file:
+            return pass_file.read().strip()
+    return getpass("Keyfile's password: ")
+
+
+def load_guardian_password(args: Any):
+    if args.guardian_passfile:
+        with open(args.guardian_passfile) as pass_file:
             return pass_file.read().strip()
     return getpass("Keyfile's password: ")

--- a/multiversx_sdk_cli/cli_shared.py
+++ b/multiversx_sdk_cli/cli_shared.py
@@ -10,7 +10,7 @@ from multiversx_sdk_network_providers.proxy_network_provider import \
 from multiversx_sdk_cli import config, errors, utils
 from multiversx_sdk_cli.accounts import Account
 from multiversx_sdk_cli.cli_output import CLIOutputBuilder
-from multiversx_sdk_cli.cli_password import load_password
+from multiversx_sdk_cli.cli_password import load_password, load_guardian_password
 from multiversx_sdk_cli.ledger.ledger_functions import do_get_ledger_address
 from multiversx_sdk_cli.simulation import Simulator
 from multiversx_sdk_cli.transactions import Transaction
@@ -154,7 +154,7 @@ def prepare_guardian_account(args: Any):
     if args.guardian_pem:
         account = Account(pem_file=args.guardian_pem, pem_index=args.guardian_pem_index)
     elif args.guardian_keyfile:
-        password = load_password(args)
+        password = load_guardian_password(args)
         account = Account(key_file=args.guardian_keyfile, password=password)
     elif args.guardian_ledger:
         address = do_get_ledger_address(account_index=args.guardian_ledger_account_index, address_index=args.guardian_ledger_address_index)
@@ -196,18 +196,18 @@ def check_guardian_and_options_args(args: Any):
 
 def check_guardian_args(args: Any):
     if args.guardian:
-        if sign_with_cosigner_service(args) and sign_with_guardian_key(args):
+        if should_sign_with_cosigner_service(args) and should_sign_with_guardian_key(args):
             raise errors.BadUsage("Guarded tx should be signed using either a cosigning service or a guardian key")
 
-        if not sign_with_cosigner_service(args) and not sign_with_guardian_key(args):
-            raise errors.BadUsage("All guardian arguments must be provided")
+        if not should_sign_with_cosigner_service(args) and not should_sign_with_guardian_key(args):
+            raise errors.BadUsage("Missing guardian signing arguments")
 
 
-def sign_with_cosigner_service(args: Any) -> bool:
+def should_sign_with_cosigner_service(args: Any) -> bool:
     return all([args.guardian_service_url, args.guardian_2fa_code])
 
 
-def sign_with_guardian_key(args: Any) -> bool:
+def should_sign_with_guardian_key(args: Any) -> bool:
     return any([args.guardian_pem, args.guardian_keyfile, args.guardian_ledger])
 
 

--- a/multiversx_sdk_cli/cli_shared.py
+++ b/multiversx_sdk_cli/cli_shared.py
@@ -195,9 +195,20 @@ def check_guardian_and_options_args(args: Any):
 
 
 def check_guardian_args(args: Any):
-    if any([args.guardian, args.guardian_service_url, args.guardian_2fa_code]):
-        if not all([args.guardian, args.guardian_service_url, args.guardian_2fa_code]):
+    if args.guardian:
+        if sign_with_cosigner_service(args) and sign_with_guardian_key(args):
+            raise errors.BadUsage("Guarded tx should be signed using either a cosigning service or a guardian key")
+
+        if not sign_with_cosigner_service(args) and not sign_with_guardian_key(args):
             raise errors.BadUsage("All guardian arguments must be provided")
+
+
+def sign_with_cosigner_service(args: Any) -> bool:
+    return all([args.guardian_service_url, args.guardian_2fa_code])
+
+
+def sign_with_guardian_key(args: Any) -> bool:
+    return any([args.guardian_pem, args.guardian_keyfile, args.guardian_ledger])
 
 
 def check_options_for_guarded_tx(options: int):

--- a/multiversx_sdk_cli/cli_shared.py
+++ b/multiversx_sdk_cli/cli_shared.py
@@ -101,6 +101,16 @@ def add_wallet_args(args: List[str], sub: Any):
     sub.add_argument("--sender-username", required=False, help="🖄 the username of the sender")
 
 
+def add_guardian_wallet_args(args: List[str], sub: Any):
+    sub.add_argument("--guardian-pem", required=check_if_sign_method_required(args, "--guardian-pem"), help="🔑 the PEM file, if keyfile not provided")
+    sub.add_argument("--guardian-pem-index", default=0, help="🔑 the index in the PEM file (default: %(default)s)")
+    sub.add_argument("--guardian-keyfile", required=check_if_sign_method_required(args, "--guardian-keyfile"), help="🔑 a JSON keyfile, if PEM not provided")
+    sub.add_argument("--guardian-passfile", help="🔑 a file containing keyfile's password, if keyfile provided")
+    sub.add_argument("--guardian-ledger", action="store_true", required=check_if_sign_method_required(args, "--guardian-ledger"), default=False, help="🔐 bool flag for signing transaction using ledger")
+    sub.add_argument("--guardian-ledger-account-index", type=int, default=0, help="🔐 the index of the account when using Ledger")
+    sub.add_argument("--guardian-ledger-address-index", type=int, default=0, help="🔐 the index of the address when using Ledger")
+
+
 def add_proxy_arg(sub: Any):
     sub.add_argument("--proxy", default=config.get_proxy(), help="🔗 the URL of the proxy (default: %(default)s)")
 
@@ -133,6 +143,21 @@ def prepare_account(args: Any):
         account = Account(key_file=args.keyfile, password=password)
     elif args.ledger:
         address = do_get_ledger_address(account_index=args.ledger_account_index, address_index=args.ledger_address_index)
+        account = Account(address=address)
+    else:
+        raise errors.NoWalletProvided()
+
+    return account
+
+
+def prepare_guardian_account(args: Any):
+    if args.guardian_pem:
+        account = Account(pem_file=args.guardian_pem, pem_index=args.guardian_pem_index)
+    elif args.guardian_keyfile:
+        password = load_password(args)
+        account = Account(key_file=args.guardian_keyfile, password=password)
+    elif args.guardian_ledger:
+        address = do_get_ledger_address(account_index=args.guardian_ledger_account_index, address_index=args.guardian_ledger_address_index)
         account = Account(address=address)
     else:
         raise errors.NoWalletProvided()

--- a/multiversx_sdk_cli/cli_transactions.py
+++ b/multiversx_sdk_cli/cli_transactions.py
@@ -122,10 +122,10 @@ def sign_transaction(args: Any):
     except NoWalletProvided:
         guardian_account = None
 
-    if args.guardian:
-        tx = cosign_transaction(tx, args.guardian_service_url, args.guardian_2fa_code)
-    elif guardian_account:
+    if guardian_account:
         tx.guardianSignature = guardian_account.sign_transaction(tx)
+    elif args.guardian:
+        tx = cosign_transaction(tx, args.guardian_service_url, args.guardian_2fa_code)
 
     tx.signature = signature
 

--- a/multiversx_sdk_cli/cli_transactions.py
+++ b/multiversx_sdk_cli/cli_transactions.py
@@ -4,6 +4,7 @@ from typing import Any, List
 from multiversx_sdk_cli import cli_shared, utils
 from multiversx_sdk_cli.cli_output import CLIOutputBuilder
 from multiversx_sdk_network_providers.proxy_network_provider import ProxyNetworkProvider
+from multiversx_sdk_cli.errors import NoWalletProvided
 from multiversx_sdk_cli.transactions import Transaction, do_prepare_transaction
 from multiversx_sdk_cli.cosign_transaction import cosign_transaction
 
@@ -17,6 +18,7 @@ def setup_parser(args: List[str], subparsers: Any) -> Any:
     cli_shared.add_outfile_arg(sub, what="signed transaction, hash")
     cli_shared.add_broadcast_args(sub, relay=True)
     cli_shared.add_proxy_arg(sub)
+    cli_shared.add_guardian_wallet_args(args, sub)
     sub.add_argument("--wait-result", action="store_true", default=False,
                      help="signal to wait for the transaction result - only valid if --send is set")
     sub.add_argument("--timeout", default=100, help="max num of seconds to wait for result"
@@ -44,6 +46,7 @@ def setup_parser(args: List[str], subparsers: Any) -> Any:
     cli_shared.add_broadcast_args(sub, relay=True)
     cli_shared.add_proxy_arg(sub)
     cli_shared.add_guardian_args(sub)
+    cli_shared.add_guardian_wallet_args(args, sub)
     sub.set_defaults(func=sign_transaction)
 
     parser.epilog = cli_shared.build_group_epilog(subparsers)
@@ -112,9 +115,18 @@ def sign_transaction(args: Any):
     tx.signature = ""
 
     account = cli_shared.prepare_account(args)
-    tx.signature = account.sign_transaction(tx)
+    signature = account.sign_transaction(tx)
+
+    try:
+        guardian_account = cli_shared.prepare_guardian_account(args)
+    except NoWalletProvided:
+        guardian_account = None
 
     if args.guardian:
         tx = cosign_transaction(tx, args.guardian_service_url, args.guardian_2fa_code)
+    elif guardian_account:
+        tx.guardianSignature = guardian_account.sign_transaction(tx)
+
+    tx.signature = signature
 
     cli_shared.send_or_simulate(tx, args)

--- a/multiversx_sdk_cli/cli_validators.py
+++ b/multiversx_sdk_cli/cli_validators.py
@@ -91,6 +91,7 @@ def _add_common_arguments(args: List[str], sub: Any):
     cli_shared.add_tx_args(args, sub, with_receiver=False, with_data=False, with_estimate_gas=True, with_guardian=True)
     cli_shared.add_broadcast_args(sub, relay=False)
     cli_shared.add_outfile_arg(sub, what="signed transaction, hash")
+    cli_shared.add_guardian_wallet_args(args, sub)
 
 
 def _add_nodes_arg(sub: Any):

--- a/multiversx_sdk_cli/transactions.py
+++ b/multiversx_sdk_cli/transactions.py
@@ -296,10 +296,10 @@ def sign_tx_by_guardian(args: Any, tx: Transaction) -> Transaction:
     sender_signature = tx.signature
     tx.signature = ""
 
-    if args.guardian:
-        tx = cosign_transaction(tx, args.guardian_service_url, args.guardian_2fa_code)  # type: ignore
-    elif guardian_account:
+    if guardian_account:
         tx.guardianSignature = guardian_account.sign_transaction(tx)
+    elif args.guardian:
+        tx = cosign_transaction(tx, args.guardian_service_url, args.guardian_2fa_code)  # type: ignore
 
     tx.signature = sender_signature
 

--- a/multiversx_sdk_cli/transactions.py
+++ b/multiversx_sdk_cli/transactions.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Protocol, Sequence, TextIO, Tuple
 
 from multiversx_sdk_cli import config, errors, utils
 from multiversx_sdk_cli.accounts import Account, Address, LedgerAccount
-from multiversx_sdk_cli.cli_password import load_password
+from multiversx_sdk_cli.cli_password import load_password, load_guardian_password
 from multiversx_sdk_cli.errors import NoWalletProvided
 from multiversx_sdk_cli.interfaces import ITransaction
 from multiversx_sdk_cli.cosign_transaction import cosign_transaction
@@ -182,11 +182,11 @@ class Transaction(ITransaction):
         if self.options:
             dictionary["options"] = int(self.options)
 
-        if self.signature:
-            dictionary["signature"] = self.signature
-
         if self.guardian:
             dictionary["guardian"] = self.guardian
+
+        if self.signature:
+            dictionary["signature"] = self.signature
 
         if self.guardianSignature:
             dictionary["guardianSignature"] = self.guardianSignature
@@ -311,7 +311,7 @@ def get_guardian_account_from_args(args: Any):
     if args.guardian_pem:
         account = Account(pem_file=args.guardian_pem, pem_index=args.guardian_pem_index)
     elif args.guardian_keyfile:
-        password = load_password(args)
+        password = load_guardian_password(args)
         account = Account(key_file=args.guardian_keyfile, password=password)
     elif args.guardian_ledger:
         address = do_get_ledger_address(account_index=args.guardian_ledger_account_index, address_index=args.guardian_ledger_address_index)

--- a/multiversx_sdk_cli/transactions.py
+++ b/multiversx_sdk_cli/transactions.py
@@ -8,8 +8,10 @@ from typing import Any, Dict, List, Protocol, Sequence, TextIO, Tuple
 from multiversx_sdk_cli import config, errors, utils
 from multiversx_sdk_cli.accounts import Account, Address, LedgerAccount
 from multiversx_sdk_cli.cli_password import load_password
+from multiversx_sdk_cli.errors import NoWalletProvided
 from multiversx_sdk_cli.interfaces import ITransaction
 from multiversx_sdk_cli.cosign_transaction import cosign_transaction
+from multiversx_sdk_cli.ledger.ledger_functions import do_get_ledger_address
 
 logger = logging.getLogger("transactions")
 
@@ -279,8 +281,42 @@ def do_prepare_transaction(args: Any) -> Transaction:
     tx.guardian = args.guardian
 
     tx.sign(account)
-
-    if args.guardian:
-        tx = cosign_transaction(tx, args.guardian_service_url, args.guardian_2fa_code)
+    tx = sign_tx_by_guardian(args, tx)
 
     return tx
+
+
+def sign_tx_by_guardian(args: Any, tx: Transaction) -> Transaction:
+    try:
+        guardian_account = get_guardian_account_from_args(args)
+    except NoWalletProvided:
+        guardian_account = None
+
+    # empty sender signature
+    sender_signature = tx.signature
+    tx.signature = ""
+
+    if args.guardian:
+        tx = cosign_transaction(tx, args.guardian_service_url, args.guardian_2fa_code)  # type: ignore
+    elif guardian_account:
+        tx.guardianSignature = guardian_account.sign_transaction(tx)
+
+    tx.signature = sender_signature
+
+    return tx
+
+
+# TODO: this is duplicated code; a proper refactoring will come later
+def get_guardian_account_from_args(args: Any):
+    if args.guardian_pem:
+        account = Account(pem_file=args.guardian_pem, pem_index=args.guardian_pem_index)
+    elif args.guardian_keyfile:
+        password = load_password(args)
+        account = Account(key_file=args.guardian_keyfile, password=password)
+    elif args.guardian_ledger:
+        address = do_get_ledger_address(account_index=args.guardian_ledger_account_index, address_index=args.guardian_ledger_address_index)
+        account = Account(address=address)
+    else:
+        raise errors.NoWalletProvided()
+
+    return account


### PR DESCRIPTION
`mxpy` is now allowing a transaction to be signed by the guardian of the sender by using a pem file, keystore file or a Ledger device.