### PR TITLE
Remove project argument from contract deploy and contract upgrade

### DIFF
--- a/multiversx_sdk_cli/cli_contracts.py
+++ b/multiversx_sdk_cli/cli_contracts.py
@@ -15,7 +15,6 @@ from multiversx_sdk_cli.contract_verification import \
 from multiversx_sdk_cli.contracts import CodeMetadata, SmartContract
 from multiversx_sdk_cli.docker import is_docker_installed, run_docker
 from multiversx_sdk_cli.errors import DockerMissingError
-from multiversx_sdk_cli.projects import load_project
 from multiversx_sdk_cli.projects.core import get_project_paths_recursively
 from multiversx_sdk_cli.transactions import Transaction
 from multiversx_sdk_cli.cosign_transaction import cosign_transaction
@@ -71,7 +70,7 @@ def setup_parser(args: List[str], subparsers: Any) -> Any:
 
     output_description = CLIOutputBuilder.describe(with_contract=True, with_transaction_on_network=True, with_simulation=True)
     sub = cli_shared.add_command_subparser(subparsers, "contract", "deploy", f"Deploy a Smart Contract.{output_description}")
-    _add_project_or_bytecode_arg(sub)
+    _add_bytecode_arg(sub)
     _add_metadata_arg(sub)
     cli_shared.add_outfile_arg(sub)
     cli_shared.add_wallet_args(args, sub)
@@ -107,7 +106,7 @@ def setup_parser(args: List[str], subparsers: Any) -> Any:
                                            f"Upgrade a previously-deployed Smart Contract.{output_description}")
     _add_contract_arg(sub)
     cli_shared.add_outfile_arg(sub)
-    _add_project_or_bytecode_arg(sub)
+    _add_bytecode_arg(sub)
     _add_metadata_arg(sub)
     cli_shared.add_wallet_args(args, sub)
     cli_shared.add_proxy_arg(sub)
@@ -191,12 +190,9 @@ def _add_recursive_arg(sub: Any):
     sub.add_argument("-r", "--recursive", dest="recursive", action="store_true", help="locate projects recursively")
 
 
-def _add_project_or_bytecode_arg(sub: Any):
-    group = sub.add_mutually_exclusive_group(required=True)
-    group.add_argument("--project", default=os.getcwd(),
-                       help="🗀 the project directory (default: current directory)")
-    group.add_argument("--bytecode", type=str,
-                       help="the file containing the WASM bytecode")
+def _add_bytecode_arg(sub: Any):
+    sub.add_argument("--bytecode", type=str,
+                     help="the file containing the WASM bytecode")
 
 
 def _add_contract_arg(sub: Any):
@@ -285,6 +281,7 @@ def run_tests(args: Any):
 
 def deploy(args: Any):
     logger.debug("deploy")
+    cli_shared.check_bytecode_args(args)
     cli_shared.check_guardian_and_options_args(args)
     cli_shared.check_broadcast_args(args)
 
@@ -310,12 +307,7 @@ def deploy(args: Any):
 
 
 def _prepare_contract(args: Any) -> SmartContract:
-    if args.bytecode and len(args.bytecode):
-        bytecode = utils.read_binary_file(Path(args.bytecode)).hex()
-    else:
-        project_path = Path(args.project)
-        project = load_project(project_path)
-        bytecode = project.get_bytecode()
+    bytecode = utils.read_binary_file(Path(args.bytecode)).hex()
 
     metadata = CodeMetadata(upgradeable=args.metadata_upgradeable, readable=args.metadata_readable,
                             payable=args.metadata_payable, payable_by_sc=args.metadata_payable_by_sc)
@@ -387,6 +379,7 @@ def call(args: Any):
 
 def upgrade(args: Any):
     logger.debug("upgrade")
+    cli_shared.check_bytecode_args(args)
     cli_shared.check_broadcast_args(args)
 
     contract_address = args.contract

--- a/multiversx_sdk_cli/cli_contracts.py
+++ b/multiversx_sdk_cli/cli_contracts.py
@@ -191,7 +191,7 @@ def _add_recursive_arg(sub: Any):
 
 
 def _add_bytecode_arg(sub: Any):
-    sub.add_argument("--bytecode", type=str,
+    sub.add_argument("--bytecode", type=str, required=True,
                      help="the file containing the WASM bytecode")
 
 
@@ -281,7 +281,6 @@ def run_tests(args: Any):
 
 def deploy(args: Any):
     logger.debug("deploy")
-    cli_shared.check_bytecode_args(args)
     cli_shared.check_guardian_and_options_args(args)
     cli_shared.check_broadcast_args(args)
 
@@ -379,7 +378,6 @@ def call(args: Any):
 
 def upgrade(args: Any):
     logger.debug("upgrade")
-    cli_shared.check_bytecode_args(args)
     cli_shared.check_broadcast_args(args)
 
     contract_address = args.contract

--- a/multiversx_sdk_cli/cli_shared.py
+++ b/multiversx_sdk_cli/cli_shared.py
@@ -180,11 +180,6 @@ def check_options_for_guarded_tx(options: int):
         raise errors.BadUsage("Invalid guarded transaction's options. The second least significant bit must be set.")
 
 
-def check_bytecode_args(args: Any):
-    if not args.bytecode and len(args.bytecode):
-        raise errors.BadUsage("'--bytecode' argument not provided")
-
-
 def send_or_simulate(tx: Transaction, args: Any, dump_output: bool = True) -> CLIOutputBuilder:
     proxy = ProxyNetworkProvider(args.proxy)
 

--- a/multiversx_sdk_cli/cli_shared.py
+++ b/multiversx_sdk_cli/cli_shared.py
@@ -180,6 +180,11 @@ def check_options_for_guarded_tx(options: int):
         raise errors.BadUsage("Invalid guarded transaction's options. The second least significant bit must be set.")
 
 
+def check_bytecode_args(args: Any):
+    if not args.bytecode and len(args.bytecode):
+        raise errors.BadUsage("'--bytecode' argument not provided")
+
+
 def send_or_simulate(tx: Transaction, args: Any, dump_output: bool = True) -> CLIOutputBuilder:
     proxy = ProxyNetworkProvider(args.proxy)
 


### PR DESCRIPTION
The `--project` argument from the `contract deploy` and `contract upgrade` commands has been removed.
It used to create confusion because when it was used, if the contract wasn't previously built it would build the contract first, then load the bytecode. If the contract was built, it wouldn't rebuild it, it would just load the existing bytecode.