### PR TITLE
Build contracts using sc-meta

### DIFF
--- a/multiversx_sdk_cli/cli_contracts.py
+++ b/multiversx_sdk_cli/cli_contracts.py
@@ -184,7 +184,7 @@ def _add_build_options_sc_meta(sub: Any):
     sub.add_argument("--wasm-suffix", type=str,
                      help="for rust projects, optionally specify the suffix of the wasm bytecode output file")
     sub.add_argument("--target-dir", type=str, help="for rust projects, forward the parameter to Cargo")
-    sub.add_argument("--wat", action="store_true", action="store_true", help="also generate a WAT file when building", default=False)
+    sub.add_argument("--wat", action="store_true", help="also generate a WAT file when building", default=False)
     sub.add_argument("--mir", action="store_true", help="also emit MIR files when building", default=False)
     sub.add_argument("--llvm-ir", action="store_true", help="also emit LL (LLVM) files when building", default=False)
     sub.add_argument("--ignore", help="ignore all directories with these names. [default: target]")

--- a/multiversx_sdk_cli/cli_contracts.py
+++ b/multiversx_sdk_cli/cli_contracts.py
@@ -184,16 +184,16 @@ def _add_build_options_sc_meta(sub: Any):
     sub.add_argument("--wasm-suffix", type=str,
                      help="for rust projects, optionally specify the suffix of the wasm bytecode output file")
     sub.add_argument("--target-dir", type=str, help="for rust projects, forward the parameter to Cargo")
-    sub.add_argument("--wat", help="also generate a WAT file when building", default=False)
-    sub.add_argument("--mir", help="also emit MIR files when building", default=False)
-    sub.add_argument("--llvm-ir", help="also emit LL (LLVM) files when building", default=False)
+    sub.add_argument("--wat", action="store_true", default=False, action="store_true", default=False, help="also generate a WAT file when building", default=False)
+    sub.add_argument("--mir", action="store_true", default=False, help="also emit MIR files when building", default=False)
+    sub.add_argument("--llvm-ir", action="store_true", default=False, help="also emit LL (LLVM) files when building", default=False)
     sub.add_argument("--ignore", help="ignore all directories with these names. [default: target]")
-    sub.add_argument("--no-imports", help="skips extracting the EI imports after building the contracts")
-    sub.add_argument("--no-abi-git-version", help="skips loading the Git version into the ABI")
-    sub.add_argument("--twiggy-top", help="generate a twiggy top report after building")
-    sub.add_argument("--twiggy-paths", help="generate a twiggy paths report after building")
-    sub.add_argument("--twiggy-monos", help="generate a twiggy monos report after building")
-    sub.add_argument("--twiggy-dominators", help="generate a twiggy dominators report after building")
+    sub.add_argument("--no-imports", action="store_true", default=False, help="skips extracting the EI imports after building the contracts")
+    sub.add_argument("--no-abi-git-version", action="store_true", default=False, help="skips loading the Git version into the ABI")
+    sub.add_argument("--twiggy-top", action="store_true", default=False, help="generate a twiggy top report after building")
+    sub.add_argument("--twiggy-paths", action="store_true", default=False, help="generate a twiggy paths report after building")
+    sub.add_argument("--twiggy-monos", action="store_true", default=False, help="generate a twiggy monos report after building")
+    sub.add_argument("--twiggy-dominators", action="store_true", default=False, help="generate a twiggy dominators report after building")
 
 
 def _add_build_options_args(sub: Any):
@@ -274,7 +274,7 @@ def clean(args: Any):
 
 def build(args: Any):
     project_paths = [Path(args.path)]
-    arg_list = cli_shared.prepare_forwarded_command_arguments(args)
+    arg_list = cli_shared.convert_args_object_to_args_list(args)
 
     for project in project_paths:
         projects.build_project(project, arg_list)

--- a/multiversx_sdk_cli/cli_contracts.py
+++ b/multiversx_sdk_cli/cli_contracts.py
@@ -40,7 +40,6 @@ def setup_parser(args: List[str], subparsers: Any) -> Any:
 
     sub = cli_shared.add_command_subparser(subparsers, "contract", "build",
                                            "Build a Smart Contract project using the appropriate buildchain.")
-    _add_project_arg(sub)
     _add_build_options_sc_meta(sub)
     sub.set_defaults(func=build)
 
@@ -175,6 +174,7 @@ def _add_project_arg(sub: Any):
 
 
 def _add_build_options_sc_meta(sub: Any):
+    sub.add_argument("--path", default=os.getcwd(), help="🗀 the project directory (default: current directory)")
     sub.add_argument("--no-wasm-opt", action="store_true", default=False,
                      help="do not optimize wasm files after the build (default: %(default)s)")
     sub.add_argument("--wasm-symbols", action="store_true", default=False,
@@ -277,21 +277,11 @@ def clean(args: Any):
 
 
 def build(args: Any):
-    project_paths = get_project_paths(args)
+    project_paths = [Path(args.path)]
     arg_list = cli_shared.prepare_forwarded_command_arguments(args)
-    _remove_project_arg(arg_list)
 
     for project in project_paths:
         projects.build_project(project, arg_list)
-
-
-# we forward the project path using the '--path` argument for sc-meta
-def _remove_project_arg(arg_list: List[str]):
-    project_index = arg_list.index("project")
-    arg_list.pop(project_index)
-
-    # pop the same index again to delete the project's path
-    arg_list.pop(project_index)
 
 
 def _prepare_build_options(args: Any) -> Dict[str, Any]:

--- a/multiversx_sdk_cli/cli_contracts.py
+++ b/multiversx_sdk_cli/cli_contracts.py
@@ -1,6 +1,5 @@
 import logging
 import os
-from email.policy import default
 from pathlib import Path
 from typing import Any, Dict, List
 

--- a/multiversx_sdk_cli/cli_contracts.py
+++ b/multiversx_sdk_cli/cli_contracts.py
@@ -260,11 +260,7 @@ def create(args: Any):
 
 def get_project_paths(args: Any) -> List[Path]:
     base_path = Path(args.project)
-    if hasattr(args, "recursive"):
-        recursive = bool(args.recursive)
-    else:
-        recursive = False
-
+    recursive = bool(args.recursive)
     if recursive:
         return get_project_paths_recursively(base_path)
     return [base_path]

--- a/multiversx_sdk_cli/cli_contracts.py
+++ b/multiversx_sdk_cli/cli_contracts.py
@@ -175,7 +175,6 @@ def _add_project_arg(sub: Any):
 
 
 def _add_build_options_sc_meta(sub: Any):
-    sub.add_argument("--debug", action="store_true", default=False, help="set debug flag (default: %(default)s)")
     sub.add_argument("--no-wasm-opt", action="store_true", default=False,
                      help="do not optimize wasm files after the build (default: %(default)s)")
     sub.add_argument("--wasm-symbols", action="store_true", default=False,
@@ -279,32 +278,20 @@ def clean(args: Any):
 
 def build(args: Any):
     project_paths = get_project_paths(args)
-    options: Dict[str, Any] = _prepare_sc_meta_build_options(args)
+    arg_list = cli_shared.prepare_forwarded_command_arguments(args)
+    _remove_project_arg(arg_list)
 
     for project in project_paths:
-        projects.build_project(project, options)
+        projects.build_project(project, arg_list)
 
 
-def _prepare_sc_meta_build_options(args: Any) -> Dict[str, Any]:
-    return {
-        "debug": args.debug,
-        "no-wasm-opt": args.no_wasm_opt,
-        "target-dir": args.target_dir,
-        "wasm-symbols": args.wasm_symbols,
-        "wasm-name": args.wasm_name,
-        "wasm-suffix": args.wasm_suffix,
-        "target-dir": args.target_dir,
-        "wat": args.wat,
-        "mir": args.mir,
-        "llvm-ir": args.llvm_ir,
-        "ignore": args.ignore,
-        "no-imports": args.no_imports,
-        "no-abi-git-version": args.no_abi_git_version,
-        "twiggy-top": args.twiggy_top,
-        "twiggy-paths": args.twiggy_paths,
-        "twiggy-monos": args.twiggy_monos,
-        "twiggy-dominators": args.twiggy_dominators
-    }
+# we forward the project path using the '--path` argument for sc-meta
+def _remove_project_arg(arg_list: List[str]):
+    project_index = arg_list.index("project")
+    arg_list.pop(project_index)
+
+    # pop the same index again to delete the project's path
+    arg_list.pop(project_index)
 
 
 def _prepare_build_options(args: Any) -> Dict[str, Any]:

--- a/multiversx_sdk_cli/cli_contracts.py
+++ b/multiversx_sdk_cli/cli_contracts.py
@@ -184,9 +184,9 @@ def _add_build_options_sc_meta(sub: Any):
     sub.add_argument("--wasm-suffix", type=str,
                      help="for rust projects, optionally specify the suffix of the wasm bytecode output file")
     sub.add_argument("--target-dir", type=str, help="for rust projects, forward the parameter to Cargo")
-    sub.add_argument("--wat", action="store_true", default=False, action="store_true", default=False, help="also generate a WAT file when building", default=False)
-    sub.add_argument("--mir", action="store_true", default=False, help="also emit MIR files when building", default=False)
-    sub.add_argument("--llvm-ir", action="store_true", default=False, help="also emit LL (LLVM) files when building", default=False)
+    sub.add_argument("--wat", action="store_true", action="store_true", help="also generate a WAT file when building", default=False)
+    sub.add_argument("--mir", action="store_true", help="also emit MIR files when building", default=False)
+    sub.add_argument("--llvm-ir", action="store_true", help="also emit LL (LLVM) files when building", default=False)
     sub.add_argument("--ignore", help="ignore all directories with these names. [default: target]")
     sub.add_argument("--no-imports", action="store_true", default=False, help="skips extracting the EI imports after building the contracts")
     sub.add_argument("--no-abi-git-version", action="store_true", default=False, help="skips loading the Git version into the ABI")

--- a/multiversx_sdk_cli/cli_shared.py
+++ b/multiversx_sdk_cli/cli_shared.py
@@ -1,8 +1,9 @@
 import argparse
 import ast
+import copy
 import sys
 from argparse import FileType
-from typing import Any, List, Text, cast
+from typing import Any, Dict, List, Text, cast
 
 from multiversx_sdk_network_providers.proxy_network_provider import \
     ProxyNetworkProvider
@@ -10,11 +11,12 @@ from multiversx_sdk_network_providers.proxy_network_provider import \
 from multiversx_sdk_cli import config, errors, utils
 from multiversx_sdk_cli.accounts import Account
 from multiversx_sdk_cli.cli_output import CLIOutputBuilder
-from multiversx_sdk_cli.cli_password import load_password, load_guardian_password
+from multiversx_sdk_cli.cli_password import (load_guardian_password,
+                                             load_password)
+from multiversx_sdk_cli.constants import TRANSACTION_OPTIONS_TX_GUARDED
 from multiversx_sdk_cli.ledger.ledger_functions import do_get_ledger_address
 from multiversx_sdk_cli.simulation import Simulator
 from multiversx_sdk_cli.transactions import Transaction
-from multiversx_sdk_cli.constants import TRANSACTION_OPTIONS_TX_GUARDED
 
 
 def wider_help_formatter(prog: Text):
@@ -259,3 +261,20 @@ def check_if_sign_method_required(args: List[str], checked_method: str) -> bool:
             return False
 
     return True
+
+
+def prepare_forwarded_command_arguments(args: Any) -> List[str]:
+    arguments = copy.deepcopy(args)
+    args_dict: Dict[str, Any] = arguments.__dict__
+
+    # delete the function key because we don't need to pass it along
+    args_dict.pop("func")
+
+    args_list: List[str] = []
+    for key, val in args_dict.items():
+        modified_key = key.replace("_", "-")
+
+        if val:
+            args_list.extend([modified_key, val])
+
+    return args_list

--- a/multiversx_sdk_cli/cli_shared.py
+++ b/multiversx_sdk_cli/cli_shared.py
@@ -3,6 +3,7 @@ import ast
 import copy
 import sys
 from argparse import FileType
+from pathlib import Path
 from typing import Any, Dict, List, Text, cast
 
 from multiversx_sdk_network_providers.proxy_network_provider import \
@@ -272,7 +273,10 @@ def prepare_forwarded_command_arguments(args: Any) -> List[str]:
 
     args_list: List[str] = []
     for key, val in args_dict.items():
-        modified_key = key.replace("_", "-")
+        if key == "path":
+            val = str(Path(val).resolve())
+
+        modified_key = "--" + key.replace("_", "-")
 
         if val:
             args_list.extend([modified_key, val])

--- a/multiversx_sdk_cli/cli_shared.py
+++ b/multiversx_sdk_cli/cli_shared.py
@@ -264,7 +264,7 @@ def check_if_sign_method_required(args: List[str], checked_method: str) -> bool:
     return True
 
 
-def prepare_forwarded_command_arguments(args: Any) -> List[str]:
+def convert_args_object_to_args_list(args: Any) -> List[str]:
     arguments = copy.deepcopy(args)
     args_dict: Dict[str, Any] = arguments.__dict__
 
@@ -274,6 +274,10 @@ def prepare_forwarded_command_arguments(args: Any) -> List[str]:
     args_list: List[str] = []
     for key, val in args_dict.items():
         modified_key = "--" + key.replace("_", "-")
+
+        if isinstance(val, bool) and val:
+            args_list.extend([modified_key])
+            continue
 
         if val:
             args_list.extend([modified_key, val])

--- a/multiversx_sdk_cli/cli_shared.py
+++ b/multiversx_sdk_cli/cli_shared.py
@@ -273,9 +273,6 @@ def prepare_forwarded_command_arguments(args: Any) -> List[str]:
 
     args_list: List[str] = []
     for key, val in args_dict.items():
-        if key == "path":
-            val = str(Path(val).resolve())
-
         modified_key = "--" + key.replace("_", "-")
 
         if val:

--- a/multiversx_sdk_cli/projects/core.py
+++ b/multiversx_sdk_cli/projects/core.py
@@ -30,14 +30,14 @@ def load_project(directory: Path) -> Project:
         raise errors.NotSupportedProject(str(directory))
 
 
-def build_project(directory: Path, forwarded_args: List[str]):
+def build_project(directory: Path, args: List[str]):
     directory = directory.expanduser()
 
     logger.info("build_project.directory: %s", directory)
 
     guards.is_directory(directory)
     project = load_project(directory)
-    outputs = project.build(forwarded_args)
+    outputs = project.build(args)
     logger.info("Build ran.")
     for output_wasm_file in outputs:
         logger.info(f"WASM file generated: {output_wasm_file}")

--- a/multiversx_sdk_cli/projects/core.py
+++ b/multiversx_sdk_cli/projects/core.py
@@ -30,15 +30,14 @@ def load_project(directory: Path) -> Project:
         raise errors.NotSupportedProject(str(directory))
 
 
-def build_project(directory: Path, options: Dict[str, Any]):
+def build_project(directory: Path, forwarded_args: List[str]):
     directory = directory.expanduser()
 
     logger.info("build_project.directory: %s", directory)
-    logger.info("build_project.debug: %s", options['debug'])
 
     guards.is_directory(directory)
     project = load_project(directory)
-    outputs = project.build(options)
+    outputs = project.build(forwarded_args)
     logger.info("Build ran.")
     for output_wasm_file in outputs:
         logger.info(f"WASM file generated: {output_wasm_file}")

--- a/multiversx_sdk_cli/projects/project_base.py
+++ b/multiversx_sdk_cli/projects/project_base.py
@@ -21,9 +21,10 @@ class Project(IProject):
         self.path = directory.expanduser().resolve()
         self.directory = str(self.path)
 
-    def build(self, options: Union[Dict[str, Any], None] = None) -> List[Path]:
+    def build(self, forwarded_args: List[str], options: Union[Dict[str, Any], None] = None) -> List[Path]:
         migrate_project_config_file(self.path)
 
+        self.forwarded_args = forwarded_args
         self.options = options or dict()
         self.debug = self.options.get("debug", False)
         self._ensure_dependencies_installed()

--- a/multiversx_sdk_cli/projects/project_base.py
+++ b/multiversx_sdk_cli/projects/project_base.py
@@ -21,10 +21,9 @@ class Project(IProject):
         self.path = directory.expanduser().resolve()
         self.directory = str(self.path)
 
-    def build(self, forwarded_args: List[str], options: Union[Dict[str, Any], None] = None) -> List[Path]:
+    def build(self, args: List[str], options: Union[Dict[str, Any], None] = None) -> List[Path]:
         migrate_project_config_file(self.path)
-
-        self.forwarded_args = forwarded_args
+        self.forwarded_args = args
         self.options = options or dict()
         self.debug = self.options.get("debug", False)
         self._ensure_dependencies_installed()

--- a/multiversx_sdk_cli/projects/project_rust.py
+++ b/multiversx_sdk_cli/projects/project_rust.py
@@ -70,60 +70,11 @@ class ProjectRust(Project):
             self.directory
         ]
 
-        self.decorate_cargo_args(args)
+        args.extend(self.forwarded_args)
 
         return_code = subprocess.check_call(args, env=env, cwd=cwd)
         if return_code != 0:
             raise errors.BuildError(f"error code = {return_code}, see output")
-
-    def decorate_cargo_args(self, args: List[str]):
-        target_dir: str = self.options.get("target-dir", "")
-        target_dir = self._ensure_cargo_target_dir(target_dir)
-        no_wasm_opt = self.options.get("no-wasm-opt")
-        wasm_symbols = self.options.get("wasm-symbols")
-        wasm_name = self.options.get("wasm-name")
-        wasm_suffix = self.options.get("wasm-suffix")
-        wat = self.options.get("wat")
-        mir = self.options.get("mir")
-        llvm_ir = self.options.get("llvm-ir")
-        ignore = self.options.get("ignore")
-        no_imports = self.options.get("no-imports")
-        no_abi_git_version = self.options.get("no-abi-git-version")
-        twiggy_top = self.options.get("twiggy-top")
-        twiggy_paths = self.options.get("twiggy-paths")
-        twiggy_monos = self.options.get("twiggy-monos")
-        twiggy_dominators = self.options.get("twiggy-dominators")
-
-        args.extend(["--target-dir", target_dir])
-
-        if ignore:
-            args.extend(["--ignore", ignore])
-        if no_wasm_opt:
-            args.extend(["--no-wasm-opt"])
-        if wasm_symbols:
-            args.extend(["--wasm-symbols"])
-        if wasm_name:
-            args.extend(["--wasm-name", wasm_name])
-        if wasm_suffix:
-            args.extend(["--wasm-suffix", wasm_suffix])
-        if wat:
-            args.extend(["--wat"])
-        if mir:
-            args.extend(["--mir"])
-        if llvm_ir:
-            args.extend(["--llvm-ir"])
-        if no_imports:
-            args.extend(["--no-imports"])
-        if no_abi_git_version:
-            args.extend(["--no-abi-git-version"])
-        if twiggy_top:
-            args.extend(["--twiggy-top"])
-        if twiggy_paths:
-            args.extend(["--twiggy-paths"])
-        if twiggy_monos:
-            args.extend(["--twiggy-monos"])
-        if twiggy_dominators:
-            args.extend(["--twiggy-dominators"])
 
     def _ensure_cargo_target_dir(self, target_dir: str):
         default_target_dir = str(workstation.get_tools_folder() / DEFAULT_CARGO_TARGET_DIR_NAME)

--- a/multiversx_sdk_cli/projects/project_rust.py
+++ b/multiversx_sdk_cli/projects/project_rust.py
@@ -62,30 +62,40 @@ class ProjectRust(Project):
             wasm_opt = dependencies.get_module_by_key("wasm-opt")
             env = merge_env(env, wasm_opt.get_env())
 
-        # run the meta executable with the arguments `build --target=...`
         args = [
-            "cargo",
-            "run",
+            "sc-meta",
+            "all",
             "build",
+            "--path",
+            self.directory
         ]
-
-        self.prepare_build_wasm_args(args)
-        self.decorate_cargo_args(args)
 
         return_code = subprocess.check_call(args, env=env, cwd=cwd)
         if return_code != 0:
             raise errors.BuildError(f"error code = {return_code}, see output")
 
     def decorate_cargo_args(self, args: List[str]):
-        target_dir: str = self.options.get("cargo-target-dir", "")
+        target_dir: str = self.options.get("target-dir", "")
         target_dir = self._ensure_cargo_target_dir(target_dir)
         no_wasm_opt = self.options.get("no-wasm-opt")
         wasm_symbols = self.options.get("wasm-symbols")
         wasm_name = self.options.get("wasm-name")
         wasm_suffix = self.options.get("wasm-suffix")
+        wat = self.options.get("wat")
+        mir = self.options.get("mir")
+        llvm_ir = self.options.get("llvm-ir")
+        ignore = self.options.get("ignore")
+        no_imports = self.options.get("no-imports")
+        no_abi_git_version = self.options.get("no-abi-git-version")
+        twiggy_top = self.options.get("twiggy-top")
+        twiggy_paths = self.options.get("twiggy-paths")
+        twiggy_monos = self.options.get("twiggy-monos")
+        twiggy_dominators = self.options.get("twiggy-dominators")
 
         args.extend(["--target-dir", target_dir])
 
+        if ignore:
+            args.extend(["--ignore", ignore])
         if no_wasm_opt:
             args.extend(["--no-wasm-opt"])
         if wasm_symbols:
@@ -94,6 +104,24 @@ class ProjectRust(Project):
             args.extend(["--wasm-name", wasm_name])
         if wasm_suffix:
             args.extend(["--wasm-suffix", wasm_suffix])
+        if wat:
+            args.extend(["--wat"])
+        if mir:
+            args.extend(["--mir"])
+        if llvm_ir:
+            args.extend(["--llvm-ir"])
+        if no_imports:
+            args.extend(["--no-imports"])
+        if no_abi_git_version:
+            args.extend(["--no-abi-git-version"])
+        if twiggy_top:
+            args.extend(["--twiggy-top"])
+        if twiggy_paths:
+            args.extend(["--twiggy-paths"])
+        if twiggy_monos:
+            args.extend(["--twiggy-monos"])
+        if twiggy_dominators:
+            args.extend(["--twiggy-dominators"])
 
     def _ensure_cargo_target_dir(self, target_dir: str):
         default_target_dir = str(workstation.get_tools_folder() / DEFAULT_CARGO_TARGET_DIR_NAME)

--- a/multiversx_sdk_cli/projects/project_rust.py
+++ b/multiversx_sdk_cli/projects/project_rust.py
@@ -65,9 +65,7 @@ class ProjectRust(Project):
         args = [
             "sc-meta",
             "all",
-            "build",
-            "--path",
-            self.directory
+            "build"
         ]
 
         args.extend(self.forwarded_args)

--- a/multiversx_sdk_cli/projects/project_rust.py
+++ b/multiversx_sdk_cli/projects/project_rust.py
@@ -53,7 +53,6 @@ class ProjectRust(Project):
         ])
 
     def run_meta(self):
-        cwd = self.get_meta_folder()
         env = self.get_env()
 
         with_wasm_opt = not self.options.get("no-wasm-opt")
@@ -70,7 +69,7 @@ class ProjectRust(Project):
 
         args.extend(self.forwarded_args)
 
-        return_code = subprocess.check_call(args, env=env, cwd=cwd)
+        return_code = subprocess.check_call(args, env=env)
         if return_code != 0:
             raise errors.BuildError(f"error code = {return_code}, see output")
 

--- a/multiversx_sdk_cli/projects/project_rust.py
+++ b/multiversx_sdk_cli/projects/project_rust.py
@@ -70,6 +70,8 @@ class ProjectRust(Project):
             self.directory
         ]
 
+        self.decorate_cargo_args(args)
+
         return_code = subprocess.check_call(args, env=env, cwd=cwd)
         if return_code != 0:
             raise errors.BuildError(f"error code = {return_code}, see output")

--- a/multiversx_sdk_cli/tests/test_cli_contracts.sh
+++ b/multiversx_sdk_cli/tests/test_cli_contracts.sh
@@ -24,23 +24,23 @@ testBuildContracts() {
     export TARGET_DIR=$(pwd)/${SANDBOX}/TARGET
     mkdir -p ${TARGET_DIR}
 
-    ${CLI} contract build ${SANDBOX}/myadder-rs --target-dir=${TARGET_DIR} || return 1
+    ${CLI} contract build --path=${SANDBOX}/myadder-rs --target-dir=${TARGET_DIR} || return 1
     assertFileExists ${SANDBOX}/myadder-rs/output/myadder-rs.wasm || return 1
     assertFileExists ${SANDBOX}/myadder-rs/output/myadder-rs.abi.json || return 1
 
-    ${CLI} contract build ${SANDBOX}/myfactorial-rs --target-dir=${TARGET_DIR} || return 1
+    ${CLI} contract build --path=${SANDBOX}/myfactorial-rs --target-dir=${TARGET_DIR} || return 1
     assertFileExists ${SANDBOX}/myfactorial-rs/output/myfactorial-rs.wasm || return 1
     assertFileExists ${SANDBOX}/myfactorial-rs/output/myfactorial-rs.abi.json || return 1
 
-    ${CLI} contract build ${SANDBOX}/mybubbles-rs --target-dir=${TARGET_DIR} || return 1
+    ${CLI} contract build --path=${SANDBOX}/mybubbles-rs --target-dir=${TARGET_DIR} || return 1
     assertFileExists ${SANDBOX}/mybubbles-rs/output/mybubbles-rs.wasm || return 1
     assertFileExists ${SANDBOX}/mybubbles-rs/output/mybubbles-rs.abi.json || return 1
 
-    ${CLI} contract build ${SANDBOX}/mylottery-rs --target-dir=${TARGET_DIR} || return 1
+    ${CLI} contract build --path=${SANDBOX}/mylottery-rs --target-dir=${TARGET_DIR} || return 1
     assertFileExists ${SANDBOX}/mylottery-rs/output/mylottery-rs.wasm || return 1
     assertFileExists ${SANDBOX}/mylottery-rs/output/mylottery-rs.abi.json || return 1
 
-    ${CLI} contract build ${SANDBOX}/myfunding-rs --target-dir=${TARGET_DIR} || return 1
+    ${CLI} contract build --path=${SANDBOX}/myfunding-rs --target-dir=${TARGET_DIR} || return 1
     assertFileExists ${SANDBOX}/myfunding-rs/output/myfunding-rs.wasm || return 1
     assertFileExists ${SANDBOX}/myfunding-rs/output/myfunding-rs.abi.json || return 1
 }
@@ -58,7 +58,7 @@ testWasmName() {
    
     ${CLI} contract clean ${SANDBOX}/myadder-rs
     assertFileDoesNotExist ${SANDBOX}/myadder-rs/output/myadder-2-rs.wasm || return 1
-    ${CLI} contract build ${SANDBOX}/myadder-rs --target-dir=${TARGET_DIR} --wasm-name myadder-2-rs || return 1
+    ${CLI} contract build --path=${SANDBOX}/myadder-rs --target-dir=${TARGET_DIR} --wasm-name myadder-2-rs || return 1
     assertFileExists ${SANDBOX}/myadder-rs/output/myadder-2-rs.wasm || return 1
     assertFileExists ${SANDBOX}/myadder-rs/output/myadder-rs.abi.json || return 1
 }

--- a/multiversx_sdk_cli/tests/test_cli_contracts.sh
+++ b/multiversx_sdk_cli/tests/test_cli_contracts.sh
@@ -24,23 +24,23 @@ testBuildContracts() {
     export TARGET_DIR=$(pwd)/${SANDBOX}/TARGET
     mkdir -p ${TARGET_DIR}
 
-    ${CLI} contract build ${SANDBOX}/myadder-rs --cargo-target-dir=${TARGET_DIR} || return 1
+    ${CLI} contract build ${SANDBOX}/myadder-rs --target-dir=${TARGET_DIR} || return 1
     assertFileExists ${SANDBOX}/myadder-rs/output/myadder-rs.wasm || return 1
     assertFileExists ${SANDBOX}/myadder-rs/output/myadder-rs.abi.json || return 1
 
-    ${CLI} contract build ${SANDBOX}/myfactorial-rs --cargo-target-dir=${TARGET_DIR} || return 1
+    ${CLI} contract build ${SANDBOX}/myfactorial-rs --target-dir=${TARGET_DIR} || return 1
     assertFileExists ${SANDBOX}/myfactorial-rs/output/myfactorial-rs.wasm || return 1
     assertFileExists ${SANDBOX}/myfactorial-rs/output/myfactorial-rs.abi.json || return 1
 
-    ${CLI} contract build ${SANDBOX}/mybubbles-rs --cargo-target-dir=${TARGET_DIR} || return 1
+    ${CLI} contract build ${SANDBOX}/mybubbles-rs --target-dir=${TARGET_DIR} || return 1
     assertFileExists ${SANDBOX}/mybubbles-rs/output/mybubbles-rs.wasm || return 1
     assertFileExists ${SANDBOX}/mybubbles-rs/output/mybubbles-rs.abi.json || return 1
 
-    ${CLI} contract build ${SANDBOX}/mylottery-rs --cargo-target-dir=${TARGET_DIR} || return 1
+    ${CLI} contract build ${SANDBOX}/mylottery-rs --target-dir=${TARGET_DIR} || return 1
     assertFileExists ${SANDBOX}/mylottery-rs/output/mylottery-rs.wasm || return 1
     assertFileExists ${SANDBOX}/mylottery-rs/output/mylottery-rs.abi.json || return 1
 
-    ${CLI} contract build ${SANDBOX}/myfunding-rs --cargo-target-dir=${TARGET_DIR} || return 1
+    ${CLI} contract build ${SANDBOX}/myfunding-rs --target-dir=${TARGET_DIR} || return 1
     assertFileExists ${SANDBOX}/myfunding-rs/output/myfunding-rs.wasm || return 1
     assertFileExists ${SANDBOX}/myfunding-rs/output/myfunding-rs.abi.json || return 1
 }
@@ -58,7 +58,7 @@ testWasmName() {
    
     ${CLI} contract clean ${SANDBOX}/myadder-rs
     assertFileDoesNotExist ${SANDBOX}/myadder-rs/output/myadder-2-rs.wasm || return 1
-    ${CLI} contract build ${SANDBOX}/myadder-rs --cargo-target-dir=${TARGET_DIR} --wasm-name myadder-2-rs || return 1
+    ${CLI} contract build ${SANDBOX}/myadder-rs --target-dir=${TARGET_DIR} --wasm-name myadder-2-rs || return 1
     assertFileExists ${SANDBOX}/myadder-rs/output/myadder-2-rs.wasm || return 1
     assertFileExists ${SANDBOX}/myadder-rs/output/myadder-rs.abi.json || return 1
 }

--- a/multiversx_sdk_cli/tests/test_cli_shared.py
+++ b/multiversx_sdk_cli/tests/test_cli_shared.py
@@ -1,0 +1,50 @@
+from multiversx_sdk_cli.cli_shared import convert_args_object_to_args_list
+
+
+class ContractBuildArgs:
+    def __init__(self) -> None:
+        self.verbose = False
+        self.path = "testadata-out/SANDBOX/myadder-rs"
+        self.no_wasm_opt = False
+        self.wasm_symbols = False
+        self.wasm_name = None
+        self.wasm_suffix = None
+        self.target_dir = None
+        self.wat = False
+        self.mir = False
+        self.llvm_ir = False
+        self.ignore = None
+        self.no_imports = False
+        self.no_abi_git_version = False
+        self.twiggy_top = False
+        self.twiggy_paths = False
+        self.twiggy_monos = False
+        self.twiggy_dominators = False
+        self.func = "should be a func object"
+
+
+def test_args_obj_to_list():
+    contract_build_args = ContractBuildArgs()
+
+    args_list = convert_args_object_to_args_list(contract_build_args)
+
+    assert len(args_list) == 2
+    assert args_list[0] == "--path"
+    assert args_list[1] == contract_build_args.path
+
+    contract_build_args.no_wasm_opt = True
+    args_list = convert_args_object_to_args_list(contract_build_args)
+
+    assert len(args_list) == 3
+    assert args_list[0] == "--path"
+    assert args_list[1] == contract_build_args.path
+    assert args_list[2] == "--no-wasm-opt"
+
+    contract_build_args.ignore = "random_directory"
+    contract_build_args.no_imports = True
+    args_list = convert_args_object_to_args_list(contract_build_args)
+
+    assert len(args_list) == 6
+    assert args_list[3] == "--ignore"
+    assert args_list[4] == contract_build_args.ignore
+    assert args_list[5] == "--no-imports"


### PR DESCRIPTION
Previously, building a contract was done using `cargo run build` and now it's done using the `sc-meta`.

This PR contains **breaking changes**.

When building a contract before, the directory of the contract was specified as a *positional argument*, whereas now the contract directory should be specified using the `--path` argument. The default value is still the *current working directory*.
