### PR TITLE
Contract clean using sc-meta

### DIFF
--- a/multiversx_sdk_cli/cli_contracts.py
+++ b/multiversx_sdk_cli/cli_contracts.py
@@ -44,8 +44,7 @@ def setup_parser(args: List[str], subparsers: Any) -> Any:
     sub.set_defaults(func=build)
 
     sub = cli_shared.add_command_subparser(subparsers, "contract", "clean", "Clean a Smart Contract project.")
-    _add_project_arg(sub)
-    _add_recursive_arg(sub)
+    sub.add_argument("--path", default=os.getcwd(), help="🗀 the project directory (default: current directory)")
     sub.set_defaults(func=clean)
 
     sub = cli_shared.add_command_subparser(subparsers, "contract", "test", "Run scenarios (tests).")
@@ -267,9 +266,8 @@ def get_project_paths(args: Any) -> List[Path]:
 
 
 def clean(args: Any):
-    project_paths = get_project_paths(args)
-    for project in project_paths:
-        projects.clean_project(project)
+    project_path = args.path
+    projects.clean_project(Path(project_path))
 
 
 def build(args: Any):

--- a/multiversx_sdk_cli/cli_contracts.py
+++ b/multiversx_sdk_cli/cli_contracts.py
@@ -44,7 +44,7 @@ def setup_parser(args: List[str], subparsers: Any) -> Any:
     sub.set_defaults(func=build)
 
     sub = cli_shared.add_command_subparser(subparsers, "contract", "clean", "Clean a Smart Contract project.")
-    sub.add_argument("--path", default=os.getcwd(), help="🗀 the project directory (default: current directory)")
+    sub.add_argument("--path", default=os.getcwd(), help="the project directory (default: current directory)")
     sub.set_defaults(func=clean)
 
     sub = cli_shared.add_command_subparser(subparsers, "contract", "test", "Run scenarios (tests).")
@@ -173,7 +173,7 @@ def _add_project_arg(sub: Any):
 
 
 def _add_build_options_sc_meta(sub: Any):
-    sub.add_argument("--path", default=os.getcwd(), help="🗀 the project directory (default: current directory)")
+    sub.add_argument("--path", default=os.getcwd(), help="the project directory (default: current directory)")
     sub.add_argument("--no-wasm-opt", action="store_true", default=False,
                      help="do not optimize wasm files after the build (default: %(default)s)")
     sub.add_argument("--wasm-symbols", action="store_true", default=False,

--- a/multiversx_sdk_cli/projects/core.py
+++ b/multiversx_sdk_cli/projects/core.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, List
 
 from multiversx_sdk_cli import dependencies, errors, guards, utils
 from multiversx_sdk_cli.projects import shared

--- a/multiversx_sdk_cli/projects/project_rust.py
+++ b/multiversx_sdk_cli/projects/project_rust.py
@@ -1,6 +1,5 @@
 import logging
 import subprocess
-from os import path
 from pathlib import Path
 from typing import Any, Dict, List, Set, cast
 
@@ -17,9 +16,17 @@ class ProjectRust(Project):
         self.cargo_file = self.get_cargo_file()
 
     def clean(self):
-        super().clean()
-        utils.remove_folder(path.join(self.directory, "wasm", "target"))
-        utils.remove_folder(path.join(self.directory, "meta", "target"))
+        env = self.get_env()
+
+        args = [
+            "sc-meta",
+            "all",
+            "clean",
+            "--path",
+            self.directory
+        ]
+
+        subprocess.check_call(args, env=env)
 
     def get_cargo_file(self):
         cargo_path = self.path / 'Cargo.toml'

--- a/multiversx_sdk_cli/tests/test_cli_contracts.sh
+++ b/multiversx_sdk_cli/tests/test_cli_contracts.sh
@@ -56,7 +56,7 @@ testRunScenarios() {
 testWasmName() {
     echo "testWasmName"
    
-    ${CLI} contract clean ${SANDBOX}/myadder-rs
+    ${CLI} contract clean --path ${SANDBOX}/myadder-rs
     assertFileDoesNotExist ${SANDBOX}/myadder-rs/output/myadder-2-rs.wasm || return 1
     ${CLI} contract build --path=${SANDBOX}/myadder-rs --target-dir=${TARGET_DIR} --wasm-name myadder-2-rs || return 1
     assertFileExists ${SANDBOX}/myadder-rs/output/myadder-2-rs.wasm || return 1
@@ -68,31 +68,31 @@ testCleanContracts() {
 
     assertFileExists ${SANDBOX}/myadder-rs/output/myadder-rs.wasm || return 1
     assertFileExists ${SANDBOX}/myadder-rs/output/myadder-rs.abi.json || return 1
-    ${CLI} contract clean ${SANDBOX}/myadder-rs || return 1
+    ${CLI} contract clean --path ${SANDBOX}/myadder-rs || return 1
     assertFileDoesNotExist ${SANDBOX}/myadder-rs/output/myadder-rs.wasm || return 1
     assertFileDoesNotExist ${SANDBOX}/myadder-rs/output/myadder-rs.abi.json || return 1
 
     assertFileExists ${SANDBOX}/myfactorial-rs/output/myfactorial-rs.wasm || return 1
     assertFileExists ${SANDBOX}/myfactorial-rs/output/myfactorial-rs.abi.json || return 1
-    ${CLI} contract clean ${SANDBOX}/myfactorial-rs || return 1
+    ${CLI} contract clean --path ${SANDBOX}/myfactorial-rs || return 1
     assertFileDoesNotExist ${SANDBOX}/myfactorial-rs/output/myfactorial-rs.wasm || return 1
     assertFileDoesNotExist ${SANDBOX}/myfactorial-rs/output/myfactorial-rs.abi.json || return 1
 
     assertFileExists ${SANDBOX}/mybubbles-rs/output/mybubbles-rs.wasm || return 1
     assertFileExists ${SANDBOX}/mybubbles-rs/output/mybubbles-rs.abi.json || return 1
-    ${CLI} contract clean ${SANDBOX}/mybubbles-rs || return 1
+    ${CLI} contract clean --path ${SANDBOX}/mybubbles-rs || return 1
     assertFileDoesNotExist ${SANDBOX}/mybubbles-rs/output/mybubbles-rs.wasm || return 1
     assertFileDoesNotExist ${SANDBOX}/mybubbles-rs/output/mybubbles-rs.abi.json || return 1
 
     assertFileExists ${SANDBOX}/mylottery-rs/output/mylottery-rs.wasm || return 1
     assertFileExists ${SANDBOX}/mylottery-rs/output/mylottery-rs.abi.json || return 1
-    ${CLI} contract clean ${SANDBOX}/mylottery-rs || return 1
+    ${CLI} contract clean --path ${SANDBOX}/mylottery-rs || return 1
     assertFileDoesNotExist ${SANDBOX}/mylottery-rs/output/mylottery-rs.wasm || return 1
     assertFileDoesNotExist ${SANDBOX}/mylottery-rs/output/mylottery-rs.abi.json || return 1
 
     assertFileExists ${SANDBOX}/myfunding-rs/output/myfunding-rs.wasm || return 1
     assertFileExists ${SANDBOX}/myfunding-rs/output/myfunding-rs.abi.json || return 1
-    ${CLI} contract clean ${SANDBOX}/myfunding-rs || return 1
+    ${CLI} contract clean --path ${SANDBOX}/myfunding-rs || return 1
     assertFileDoesNotExist ${SANDBOX}/myfunding-rs/output/myfunding-rs.wasm || return 1
     assertFileDoesNotExist ${SANDBOX}/myfunding-rs/output/myfunding-rs.abi.json || return 1
 }


### PR DESCRIPTION
Now, for rust projects, when using `mxpy contract clean` the args are simply forwarded to `sc-meta` that takes care of cleaning the contract.
**Breaking change:** instead of passing the project path as a positional argument, `--path` **should** now be used. The default value is still the current working directory.