### PR TITLE
Install twiggy if not installed for contract report

### DIFF
--- a/multiversx_sdk_cli/cli_contracts.py
+++ b/multiversx_sdk_cli/cli_contracts.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, List
 
 from multiversx_sdk_core import Address, Transaction
 from multiversx_sdk_network_providers.proxy_network_provider import \
@@ -56,13 +56,12 @@ def setup_parser(args: List[str], subparsers: Any) -> Any:
     sub.set_defaults(func=run_tests)
 
     sub = cli_shared.add_command_subparser(subparsers, "contract", "report", "Print a detailed report of the smart contracts.")
-    _add_project_arg(sub)
     sub.add_argument("--skip-build", action="store_true", default=False, help="skips the step of building of the wasm contracts")
     sub.add_argument("--skip-twiggy", action="store_true", default=False, help="skips the steps of building the debug wasm files and running twiggy")
     sub.add_argument("--output-format", type=str, default="text-markdown", choices=["github-markdown", "text-markdown", "json"], help="report output format (default: %(default)s)")
     sub.add_argument("--output-file", type=Path, help="if specified, the output is written to a file, otherwise it's written to the standard output")
     sub.add_argument("--compare", type=Path, nargs='+', metavar=("report-1.json", "report-2.json"), help="create a comparison from two or more reports")
-    _add_build_options_args(sub)
+    _add_build_options_sc_meta(sub)
     sub.set_defaults(func=do_report)
 
     output_description = CLIOutputBuilder.describe(with_contract=True, with_transaction_on_network=True, with_simulation=True)
@@ -128,12 +127,9 @@ def setup_parser(args: List[str], subparsers: Any) -> Any:
     _add_arguments_arg(sub)
     sub.set_defaults(func=query)
 
-    sub = cli_shared.add_command_subparser(
-        subparsers,
-        "contract",
-        "verify",
-        "Verify the authenticity of the code of a deployed Smart Contract",
-    )
+    sub = cli_shared.add_command_subparser(subparsers, "contract", "verify",
+                                           "Verify the authenticity of the code of a deployed Smart Contract",
+                                           )
 
     sub.add_argument(
         "--packaged-src", required=True, help="JSON file containing the source code of the contract"
@@ -278,22 +274,9 @@ def build(args: Any):
         projects.build_project(project, arg_list)
 
 
-def _prepare_build_options(args: Any) -> Dict[str, Any]:
-    return {
-        "debug": args.debug,
-        "optimized": not args.no_optimization,
-        "no-wasm-opt": args.no_wasm_opt,
-        "verbose": args.verbose,
-        "cargo-target-dir": args.cargo_target_dir,
-        "wasm-symbols": args.wasm_symbols,
-        "wasm-name": args.wasm_name,
-        "wasm-suffix": args.wasm_suffix
-    }
-
-
 def do_report(args: Any):
-    build_options: Dict[str, Any] = _prepare_build_options(args)
-    projects.do_report(args, build_options)
+    args_dict = args.__dict__
+    projects.do_report(args, args_dict)
 
 
 def run_tests(args: Any):
@@ -479,7 +462,7 @@ def do_reproducible_build(args: Any):
 
     utils.ensure_folder(output_path)
 
-    options = _prepare_build_options(args)
+    options = args.__dict__
     no_wasm_opt = options.get("no-wasm-opt", True)
 
     if not is_docker_installed():

--- a/multiversx_sdk_cli/cli_shared.py
+++ b/multiversx_sdk_cli/cli_shared.py
@@ -296,7 +296,7 @@ def convert_args_object_to_args_list(args: Any) -> List[str]:
     args_dict: Dict[str, Any] = arguments.__dict__
 
     # delete the function key because we don't need to pass it along
-    args_dict.pop("func")
+    args_dict.pop("func", None)
 
     args_list: List[str] = []
     for key, val in args_dict.items():

--- a/multiversx_sdk_cli/projects/project_base.py
+++ b/multiversx_sdk_cli/projects/project_base.py
@@ -32,9 +32,6 @@ class Project(IProject):
         self._do_after_build_core()
         return contract_paths
 
-    def get_option(self, option_name: str) -> Any:
-        return self.options.get(option_name, None)
-
     def clean(self):
         utils.remove_folder(self.get_output_folder())
 

--- a/multiversx_sdk_cli/projects/project_rust.py
+++ b/multiversx_sdk_cli/projects/project_rust.py
@@ -128,7 +128,7 @@ class ProjectRust(Project):
         return dependencies.get_module_by_key("rust").get_env()
 
     def build_wasm_with_debug_symbols(self, build_options: Dict[str, Any]):
-        cwd = self.get_meta_folder().parent
+        cwd = self.path
         env = self.get_env()
         target_dir: str = build_options.get("target-dir", "")
         target_dir = self._ensure_cargo_target_dir(target_dir)

--- a/multiversx_sdk_cli/projects/project_rust.py
+++ b/multiversx_sdk_cli/projects/project_rust.py
@@ -128,14 +128,14 @@ class ProjectRust(Project):
         return dependencies.get_module_by_key("rust").get_env()
 
     def build_wasm_with_debug_symbols(self, build_options: Dict[str, Any]):
-        cwd = self.get_meta_folder()
+        cwd = self.get_meta_folder().parent
         env = self.get_env()
-        target_dir: str = build_options.get("cargo-target-dir", "")
+        target_dir: str = build_options.get("target-dir", "")
         target_dir = self._ensure_cargo_target_dir(target_dir)
 
         args = [
-            "cargo",
-            "run",
+            "sc-meta",
+            "all",
             "build",
             "--wasm-symbols",
             "--wasm-suffix", "dbg",

--- a/multiversx_sdk_cli/projects/report/do_report.py
+++ b/multiversx_sdk_cli/projects/report/do_report.py
@@ -29,8 +29,7 @@ def _build_report(args: Any, build_options: Dict[str, Any]) -> None:
     project_paths = get_project_paths_recursively(base_path)
     options = get_default_report_features()
 
-    args_copy = copy.deepcopy(args)
-    _prepare_args_for_build(args_copy)
+    args_copy = _prepare_args_for_build(args)
     build_args = cli_shared.convert_args_object_to_args_list(args_copy)
 
     report_creator = ReportCreator(options, skip_build=args.skip_build, skip_twiggy=args.skip_twiggy, build_options=build_options, build_args=build_args)
@@ -39,9 +38,13 @@ def _build_report(args: Any, build_options: Dict[str, Any]) -> None:
 
 
 def _prepare_args_for_build(args: Any):
-    arguments: Dict[str, Any] = args.__dict__
+    args_copy = copy.deepcopy(args)
+
+    arguments: Dict[str, Any] = args_copy.__dict__
     arguments.pop("output_format", None)
     arguments.pop("output_file", None)
+
+    return args_copy
 
 
 def _compare_reports(args: Any, merge_report_paths: List[Path]) -> None:

--- a/multiversx_sdk_cli/projects/report/do_report.py
+++ b/multiversx_sdk_cli/projects/report/do_report.py
@@ -1,14 +1,17 @@
+import copy
 import logging
 from pathlib import Path
 from typing import Any, Dict, List
-from multiversx_sdk_cli import utils
 
+from multiversx_sdk_cli import cli_shared, utils
 from multiversx_sdk_cli.projects.core import get_project_paths_recursively
-from multiversx_sdk_cli.projects.report.data.report import Report, merge_list_of_reports
-from multiversx_sdk_cli.projects.report.format.format_options import FormatOptions
-from multiversx_sdk_cli.projects.report.features.features import get_default_report_features
+from multiversx_sdk_cli.projects.report.data.report import (
+    Report, merge_list_of_reports)
+from multiversx_sdk_cli.projects.report.features.features import \
+    get_default_report_features
+from multiversx_sdk_cli.projects.report.format.format_options import \
+    FormatOptions
 from multiversx_sdk_cli.projects.report.report_creator import ReportCreator
-
 
 logger = logging.getLogger("report")
 
@@ -22,12 +25,23 @@ def do_report(args: Any, build_options: Any) -> None:
 
 
 def _build_report(args: Any, build_options: Dict[str, Any]) -> None:
-    base_path = Path(args.project)
+    base_path = Path(args.path)
     project_paths = get_project_paths_recursively(base_path)
     options = get_default_report_features()
-    report_creator = ReportCreator(options, skip_build=args.skip_build, skip_twiggy=args.skip_twiggy, build_options=build_options)
+
+    args_copy = copy.deepcopy(args)
+    _prepare_args_for_build(args_copy)
+    build_args = cli_shared.convert_args_object_to_args_list(args_copy)
+
+    report_creator = ReportCreator(options, skip_build=args.skip_build, skip_twiggy=args.skip_twiggy, build_options=build_options, build_args=build_args)
     report = report_creator.create_report(base_path, project_paths)
     _finalize_report(report, args)
+
+
+def _prepare_args_for_build(args: Any):
+    arguments: Dict[str, Any] = args.__dict__
+    arguments.pop("output_format", None)
+    arguments.pop("output_file", None)
 
 
 def _compare_reports(args: Any, merge_report_paths: List[Path]) -> None:

--- a/multiversx_sdk_cli/projects/report/features/twiggy_paths_check.py
+++ b/multiversx_sdk_cli/projects/report/features/twiggy_paths_check.py
@@ -27,24 +27,14 @@ class TwiggyPathsCheck(ReportFeature):
         return True
 
 
-def ensure_twiggy_is_installed():
-    module = dependencies.get_module_by_key("twiggy")
-    default_tag: str = config.get_dependency_tag(module.key)
-
-    installed = module.is_installed(default_tag)
-
-    if not installed:
-        logger.warning("twiggy is not installed! Installing twiggy...")
-        dependencies.install_module("twiggy")
-
-
 def run_twiggy_paths(wasm_path: Path) -> Path:
     rust = dependencies.get_module_by_key("rust")
     debug_wasm_path = _get_debug_wasm_path(wasm_path)
 
-    ensure_twiggy_is_installed()
+    dependencies.install_module("twiggy")
     twiggy_paths_args = ["twiggy", "paths", str(debug_wasm_path)]
     output = myprocess.run_process(twiggy_paths_args, env=rust.get_env(), cwd=debug_wasm_path.parent, dump_to_stdout=False)
+
     output_path = _get_twiggy_paths_path(wasm_path)
     utils.write_file(output_path, output)
     logger.info(f"Twiggy paths output path: {output_path}")

--- a/multiversx_sdk_cli/projects/report/report_creator.py
+++ b/multiversx_sdk_cli/projects/report/report_creator.py
@@ -3,27 +3,32 @@ import itertools
 import operator
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Tuple
+
 from multiversx_sdk_cli import guards
-from multiversx_sdk_cli.projects.report.data.folder_report import FolderReport
-from multiversx_sdk_cli.projects.report.data.extracted_feature import ExtractedFeature
-from multiversx_sdk_cli.projects.report.data.report import Report
-from multiversx_sdk_cli.projects.report.data.wasm_report import WasmReport
-from multiversx_sdk_cli.projects.report.data.project_report import ProjectReport
 from multiversx_sdk_cli.projects.core import load_project
 from multiversx_sdk_cli.projects.project_base import remove_suffix
 from multiversx_sdk_cli.projects.project_rust import ProjectRust
-
-from multiversx_sdk_cli.projects.report.features.report_option import ReportFeature
-from multiversx_sdk_cli.projects.report.features.twiggy_paths_check import run_twiggy_paths
+from multiversx_sdk_cli.projects.report.data.extracted_feature import \
+    ExtractedFeature
+from multiversx_sdk_cli.projects.report.data.folder_report import FolderReport
+from multiversx_sdk_cli.projects.report.data.project_report import \
+    ProjectReport
+from multiversx_sdk_cli.projects.report.data.report import Report
+from multiversx_sdk_cli.projects.report.data.wasm_report import WasmReport
+from multiversx_sdk_cli.projects.report.features.report_option import \
+    ReportFeature
+from multiversx_sdk_cli.projects.report.features.twiggy_paths_check import \
+    run_twiggy_paths
 
 
 class ReportCreator:
-    def __init__(self, options: List[ReportFeature], skip_build: bool, skip_twiggy: bool, build_options: Dict[str, Any]) -> None:
+    def __init__(self, options: List[ReportFeature], skip_build: bool, skip_twiggy: bool, build_options: Dict[str, Any], build_args: List[str]) -> None:
         self.report_features = options
         self.skip_build = skip_build
         self.skip_twiggy = skip_twiggy
         self.require_twiggy_paths = any(report_feature.requires_twiggy_paths() for report_feature in self.report_features)
         self.build_options = build_options
+        self.build_args = build_args
 
     def create_report(self, base_path: Path, project_paths: List[Path]) -> Report:
         base_path = base_path.resolve()
@@ -47,7 +52,7 @@ class ReportCreator:
         project = load_project(project_path)
 
         if not self.skip_build:
-            project.build(self.build_options)
+            project.build(self.build_args, self.build_options)
 
         twiggy_requirements_met = False
         should_build_twiggy = self.require_twiggy_paths and not self.skip_twiggy


### PR DESCRIPTION
When building a contract for `mxpy contract report` use `sc-meta` to build the contract, as well. If `twiggy` is not installed, it will be automatically installed.
Solves issue https://github.com/multiversx/mx-sdk-py-cli/issues/293.