### PR TITLE
Adjust default Rust version

### DIFF
--- a/multiversx_sdk_cli/config.py
+++ b/multiversx_sdk_cli/config.py
@@ -155,7 +155,7 @@ def get_defaults() -> Dict[str, Any]:
         "dependencies.llvm.urlTemplate.linux": "https://ide.elrond.com/vendor-llvm/{TAG}/linux-amd64.tar.gz?t=19feb",
         "dependencies.llvm.urlTemplate.osx": "https://ide.elrond.com/vendor-llvm/{TAG}/darwin-amd64.tar.gz?t=19feb",
         "dependencies.rust.resolution": "SDK",
-        "dependencies.rust.tag": "nightly",
+        "dependencies.rust.tag": "nightly-2023-04-24",
         "dependencies.golang.resolution": "SDK",
         "dependencies.golang.tag": "go1.20.5",
         "dependencies.golang.urlTemplate.linux": "https://golang.org/dl/{TAG}.linux-amd64.tar.gz",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "multiversx-sdk-cli"
-version = "7.2.1"
+version = "7.3.0"
 authors = [
   { name="MultiversX" },
 ]


### PR DESCRIPTION
Specific versions of the Rust framework aren't compatible with recent versions of Rust (nightly) - a compatibility matrix is yet to be defined / documented.

Ideally, the default Rust version installed by mxpy should be the version referenced by the latest Docker image for reproducible builds:
 - https://github.com/multiversx/mx-sdk-rust-contract-builder/blob/main/Dockerfile#L5C19-L5C37