### PR TITLE
Fix contract build in case of Rust error

### DIFF
--- a/multiversx_sdk_cli/projects/project_rust.py
+++ b/multiversx_sdk_cli/projects/project_rust.py
@@ -43,13 +43,7 @@ class ProjectRust(Project):
         if not meta:
             raise errors.NotSupportedProject("The project does not have a meta crate")
 
-        try:
-            # The meta crate handles the build process, ABI generation and
-            # allows contract developers to add extra
-            # preparation steps before building.
-            self.run_meta()
-        except subprocess.CalledProcessError as err:
-            raise errors.BuildError(err.output)
+        self.run_meta()
 
     def prepare_build_wasm_args(self, args: List[str]):
         args.extend([
@@ -76,9 +70,10 @@ class ProjectRust(Project):
 
         args.extend(self.forwarded_args)
 
-        return_code = subprocess.check_call(args, env=env)
-        if return_code != 0:
-            raise errors.BuildError(f"error code = {return_code}, see output")
+        try:
+            subprocess.check_call(args, env=env)
+        except subprocess.CalledProcessError as err:
+            raise errors.BuildError(f"error code = {err.returncode}, see output")
 
     def _ensure_cargo_target_dir(self, target_dir: str):
         default_target_dir = str(workstation.get_tools_folder() / DEFAULT_CARGO_TARGET_DIR_NAME)
@@ -143,9 +138,10 @@ class ProjectRust(Project):
             "--target-dir", target_dir
         ]
 
-        return_code = subprocess.check_call(args, env=env, cwd=cwd)
-        if return_code != 0:
-            raise errors.BuildError(f"error code = {return_code}, see output")
+        try:
+            subprocess.check_call(args, env=env, cwd=cwd)
+        except subprocess.CalledProcessError as err:
+            raise errors.BuildError(f"error code = {err.returncode}, see output")
 
 
 class CargoFile:

--- a/multiversx_sdk_cli/tests/test_cli_contracts.py
+++ b/multiversx_sdk_cli/tests/test_cli_contracts.py
@@ -1,10 +1,41 @@
 from pathlib import Path
+from typing import Any
 
 from multiversx_sdk_cli.cli import main
 
+parent = Path(__file__).parent
+
+
+def test_contract_build():
+    main([
+        "contract",
+        "build",
+        "--path",
+        f"{parent}/testdata-out/SANDBOX/myadder-rs"
+    ])
+
+    assert Path.is_file(Path(f"{parent}/testdata-out/SANDBOX/myadder-rs/output/myadder-rs.wasm"))
+
+
+def test_bad_contract_build(capsys: Any):
+    ERROR = "Build error: error code = 101, see output."
+
+    main([
+        "contract",
+        "build",
+        "--path",
+        f"{parent}/testdata-out/SANDBOX/myadder-rs-bad-src"
+    ])
+
+    out, _ = capsys.readouterr()
+
+    if ERROR in out:
+        assert True
+    else:
+        assert False
+
 
 def test_contract_deploy():
-    parent = Path(__file__).parent
     output_file = parent / "testdata-out" / "deploy.json"
 
     main(
@@ -32,7 +63,6 @@ def test_contract_deploy():
 
 
 def test_contract_upgrade():
-    parent = Path(__file__).parent
     output_file = parent / "testdata-out" / "upgrade.json"
     contract_address = "erd1qqqqqqqqqqqqqpgq5l9jl0j0gnqmm7hn82zaydwux3s5xuwkyq8srt5vsy"
 
@@ -62,7 +92,6 @@ def test_contract_upgrade():
 
 
 def test_contract_call():
-    parent = Path(__file__).parent
     output_file = parent / "testdata-out" / "call.json"
     contract_address = "erd1qqqqqqqqqqqqqpgq5l9jl0j0gnqmm7hn82zaydwux3s5xuwkyq8srt5vsy"
 


### PR DESCRIPTION
`mxpy contract build` would display `no build error` even if the Rust error was displayed in the terminal.

Fixes https://github.com/multiversx/mx-sdk-py-cli/issues/312

Also added unit tests.