### PR TITLE
Adjust default vmtools version: 1.4.60

### DIFF
--- a/multiversx_sdk_cli/config.py
+++ b/multiversx_sdk_cli/config.py
@@ -145,7 +145,7 @@ def _guard_valid_config_deletion(name: str):
 
 def get_defaults() -> Dict[str, Any]:
     return {
-        "dependencies.vmtools.tag": "latest",
+        "dependencies.vmtools.tag": "1.4.60",
         "dependencies.mx_sdk_rs.tag": "latest",
         "dependencies.vmtools.urlTemplate.linux": "https://github.com/multiversx/mx-chain-vm-go/archive/{TAG}.tar.gz",
         "dependencies.vmtools.urlTemplate.osx": "https://github.com/multiversx/mx-chain-vm-go/archive/{TAG}.tar.gz",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "multiversx-sdk-cli"
-version = "8.1.0"
+version = "8.1.1"
 authors = [
   { name="MultiversX" },
 ]


### PR DESCRIPTION
`1.4.60` is the one used here, as well:
 - https://github.com/multiversx/mx-sdk-rs/blob/master/.github/workflows/actions.yml#L19
 - https://github.com/multiversx/mx-exchange-sc/blob/main/.github/workflows/actions.yml#L26

An alternative would have been to switch to `v1.4.81`, due to:
 - https://github.com/multiversx/mx-chain-go/blob/v1.5.13/go.mod#L25C24-L25C35

In that case (of the alternative), we should have updated `dependencies.vmtools.urlTemplate.*` configuration entries, as well, to point here: https://github.com/multiversx/mx-chain-vm-v1_4-go.