### PR TITLE
Fixed sdk-py-wallet version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,17 +19,18 @@ classifiers = [
     "Intended Audience :: Developers"
 ]
 
-[dependencies]
-toml = ">=0.10.2"
-requests = "*"
-prettytable = "*"
-ledgercomm = { version = "*", extras = ["hid"] }
-semver = "*"
-requests-cache = "*"
-rich = "13.3.4"
-multiversx-sdk-network-providers = ">=0.11.0"
-multiversx-sdk-wallet = ">=0.7.0, <0.8.0"
-multiversx-sdk-core = ">=0.5.0"
+dependencies = [
+  "toml>=0.10.2",
+  "requests",
+  "prettytable",
+  "ledgercomm[hid]",
+  "semver",
+  "requests-cache",
+  "rich==13.3.4",
+  "multiversx-sdk-network-providers>=0.11.0",
+  "multiversx-sdk-wallet>=0.7.0, <0.8.0",
+  "multiversx-sdk-core>=0.5.0"
+]
 
 [tool.hatch.build]
 include = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "multiversx-sdk-cli"
-version = "8.1.2"
+version = "8.1.3"
 authors = [
   { name="MultiversX" },
 ]
@@ -18,18 +18,18 @@ classifiers = [
     "Operating System :: OS Independent",
     "Intended Audience :: Developers"
 ]
-dependencies = [
-  "toml>=0.10.2",
-  "requests",
-  "prettytable",
-  "ledgercomm[hid]",
-  "semver",
-  "requests-cache",
-  "rich==13.3.4",
-  "multiversx-sdk-network-providers>=0.11.0",
-  "multiversx-sdk-wallet>=0.7.0",
-  "multiversx-sdk-core>=0.5.0"
-]
+
+[dependencies]
+toml = ">=0.10.2"
+requests = "*"
+prettytable = "*"
+ledgercomm = { version = "*", extras = ["hid"] }
+semver = "*"
+requests-cache = "*"
+rich = "13.3.4"
+multiversx-sdk-network-providers = ">=0.11.0"
+multiversx-sdk-wallet = ">=0.7.0, <0.8.0"
+multiversx-sdk-core = ">=0.5.0"
 
 [tool.hatch.build]
 include = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ rich==13.3.4
 
 multiversx-sdk-core==0.6.0
 multiversx-sdk-network-providers>=0.11.0
-multiversx-sdk-wallet>=0.7.0
+multiversx-sdk-wallet>=0.7.0, < 0.8.0


### PR DESCRIPTION
The newly released `sdk-py-wallet` contains a few breaking changes, making `mxpy` incompatible with `sdk-py-wallet = 0.8.0`.
**mxpy** still references the older version of `sdk-py-wallet`, but the next release of mxpy, `v9.0.0` will be compatible with the latest wallet package.