### PR TITLE
Fix vmtools installation

### DIFF
--- a/multiversx_sdk_cli/dependencies/modules.py
+++ b/multiversx_sdk_cli/dependencies/modules.py
@@ -200,6 +200,11 @@ class VMToolsModule(StandaloneModule):
     def get_env(self) -> Dict[str, str]:
         return dict()
 
+    def get_source_directory(self, tag: str) -> Path:
+        directory = self.get_directory(tag)
+        first_subdirectory = next(directory.iterdir())
+        return first_subdirectory
+
 
 class GolangModule(StandaloneModule):
     def _post_install(self, tag: str):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "multiversx-sdk-cli"
-version = "8.1.3"
+version = "8.1.4"
 authors = [
   { name="MultiversX" },
 ]


### PR DESCRIPTION
Fixed the vmtools intallation, allowing one to install a specific version.
Now, doing the following works:
```
mxpy config set "dependencies.vmtools.urlTemplate.linux" "https://github.com/multiversx/mx-chain-vm-v1_4-go/archive/{TAG}.tar.gz"
mxpy config set dependencies.vmtools.tag v1.4.81
mxpy deps install vmtools --overwrite
```