### PR TITLE
Transfer and execute 

### DIFF
--- a/multiversx_sdk_cli/cli_contracts.py
+++ b/multiversx_sdk_cli/cli_contracts.py
@@ -96,6 +96,7 @@ def setup_parser(args: List[str], subparsers: Any) -> Any:
     cli_shared.add_tx_args(args, sub, with_receiver=False, with_data=False, with_guardian=True)
     _add_function_arg(sub)
     _add_arguments_arg(sub)
+    _add_token_transfers_args(sub)
     sub.add_argument("--wait-result", action="store_true", default=False,
                      help="signal to wait for the transaction result - only valid if --send is set")
     sub.add_argument("--timeout", default=100, help="max num of seconds to wait for result"
@@ -232,6 +233,12 @@ def _add_arguments_arg(sub: Any):
     sub.add_argument("--arguments", nargs='+',
                      help="arguments for the contract transaction, as [number, bech32-address, ascii string, "
                      "boolean] or hex-encoded. E.g. --arguments 42 0x64 1000 0xabba str:TOK-a1c2ef true erd1[..]")
+
+
+def _add_token_transfers_args(sub: Any):
+    sub.add_argument("--token-transfers", nargs='+',
+                     help="token transfers for transfer & execute, as [token, amount] "
+                     "E.g. --token-transfers NFT-123456-0a 1 ESDT-987654 100000000")
 
 
 def _add_metadata_arg(sub: Any):

--- a/multiversx_sdk_cli/contracts.py
+++ b/multiversx_sdk_cli/contracts.py
@@ -105,7 +105,7 @@ class SmartContract:
 
         value = int(args.value)
         transfers = args.token_transfers
-        token_transfers = self._prepare_token_transfers(transfers)
+        token_transfers = self._prepare_token_transfers(transfers) if transfers else []
 
         tx = self._factory.create_transaction_for_execute(
             sender=caller.address,
@@ -153,7 +153,7 @@ class SmartContract:
         token_computer = TokenComputer()
         token_transfers: List[TokenTransfer] = []
 
-        for i in range(len(transfers) - 1):
+        for i in range(0, len(transfers) - 1, 2):
             identifier = transfers[i]
             amount = int(transfers[i + 1])
             nonce = token_computer.extract_nonce_from_extended_identifier(identifier)

--- a/multiversx_sdk_cli/tests/test_cli_contracts.py
+++ b/multiversx_sdk_cli/tests/test_cli_contracts.py
@@ -168,6 +168,43 @@ def test_contract_call():
     assert Path.is_file(output_file) == True
 
 
+def test_contract_transfer_and_execute(capsys: Any):
+    contract_address = "erd1qqqqqqqqqqqqqpgqv7sl6ws5dgwe5m04xtg0dvqyu2efz5a6d8ssxn4k9q"
+    first_token = "NFT-123456-02"
+    second_token = "ESDT-987654"
+
+    main([
+        "contract", "call", contract_address,
+        "--pem", f"{parent}/testdata/testUser.pem",
+        "--proxy", "https://devnet-api.multiversx.com",
+        "--chain", "D",
+        "--recall-nonce",
+        "--gas-limit", "5000000",
+        "--function", "add",
+        "--arguments", "5",
+        "--token-transfers", first_token, "1"
+    ])
+    data = get_transaction_data(capsys)
+    assert data == "ESDTNFTTransfer@4e46542d313233343536@02@01@0000000000000000050067a1fd3a146a1d9a6df532d0f6b004e2b29153ba69e1@616464@05"
+
+    # Clear the captured content
+    capsys.readouterr()
+
+    main([
+        "contract", "call", contract_address,
+        "--pem", f"{parent}/testdata/testUser.pem",
+        "--proxy", "https://devnet-api.multiversx.com",
+        "--chain", "D",
+        "--recall-nonce",
+        "--gas-limit", "5000000",
+        "--function", "add",
+        "--arguments", "5",
+        "--token-transfers", first_token, "1", second_token, "100"
+    ])
+    data = get_transaction_data(capsys)
+    assert data == "MultiESDTNFTTransfer@0000000000000000050067a1fd3a146a1d9a6df532d0f6b004e2b29153ba69e1@02@4e46542d313233343536@02@01@455344542d393837363534@@64@616464@05"
+
+
 def test_contract_flow(capsys: Any):
     alice = f"{parent}/testdata/alice.pem"
     adder = f"{parent}/testdata/adder.wasm"
@@ -268,3 +305,9 @@ def get_contract_address(capsys: Any):
 def get_query_response(capsys: Any):
     out = _read_stdout(capsys).replace("\n", "").replace(" ", "")
     return json.loads(out)[0]
+
+
+def get_transaction_data(capsys: Any):
+    out = _read_stdout(capsys)
+    output = json.loads(out)
+    return output["emittedTransactionData"]


### PR DESCRIPTION
Now, when calling a contract a token transfer is also supported. To send `EGLD` the amount should be provided using `--value` and for sending `ESDT/MetaESDT/NFT` one can use `--token transfer`. The token identifier should be provided (including nonce for NFTs/MetaESDTs) followed by the amount.
e.g.
```sh
--token-transfers NFT-123456-0a 1 ESDT-987654 100000000
```