### PR TITLE
Check for deprecated entries in mxpy.json and display warning

### DIFF
--- a/multiversx_sdk_cli/cli.py
+++ b/multiversx_sdk_cli/cli.py
@@ -47,6 +47,8 @@ def _do_main(cli_args: List[str]):
     else:
         logging.basicConfig(level="INFO", format='%(name)s: %(message)s', handlers=[RichHandler(show_time=False, rich_tracebacks=True)])
 
+    verify_deprecated_entries_in_config_file()
+
     if not hasattr(args, "func"):
         parser.print_help()
     else:
@@ -101,6 +103,18 @@ COMMAND GROUPS summary
         parser.epilog += (f"{choice.ljust(30)} {sub.description}\n")
 
     return parser
+
+
+def verify_deprecated_entries_in_config_file():
+    deprecated_keys = config.get_deprecated_entries_in_config_file()
+    if len(deprecated_keys) == 0:
+        return
+    else:
+        message = "The following entries are deprecated. Please remove them from the `mxpy.json` config file. \n"
+        for entry in deprecated_keys:
+            message += f"{entry} \n"
+
+        ux.show_warning(message)
 
 
 if __name__ == "__main__":

--- a/multiversx_sdk_cli/cli.py
+++ b/multiversx_sdk_cli/cli.py
@@ -109,12 +109,12 @@ def verify_deprecated_entries_in_config_file():
     deprecated_keys = config.get_deprecated_entries_in_config_file()
     if len(deprecated_keys) == 0:
         return
-    else:
-        message = "The following entries are deprecated. Please remove them from the `mxpy.json` config file. \n"
-        for entry in deprecated_keys:
-            message += f"{entry} \n"
 
-        ux.show_warning(message)
+    message = "The following entries are deprecated. Please remove them from the `mxpy.json` config file. \n"
+    for entry in deprecated_keys:
+        message += f"{entry} \n"
+
+    ux.show_warning(message)
 
 
 if __name__ == "__main__":

--- a/multiversx_sdk_cli/config.py
+++ b/multiversx_sdk_cli/config.py
@@ -167,6 +167,12 @@ def get_defaults() -> Dict[str, Any]:
     }
 
 
+def get_deprecated_entries_in_config_file():
+    default_config_keys = set(get_defaults().keys())
+    current_config_keys = set(get_active().keys())
+    return current_config_keys - default_config_keys
+
+
 def resolve_config_path() -> Path:
     if os.path.isfile(LOCAL_CONFIG_PATH):
         return LOCAL_CONFIG_PATH


### PR DESCRIPTION
The default config contains all necessary values, so there is no point in adding extra key-value pairs in `mxpy.json`. Now, we get the active config and check if there are any extra keys compared to the default config. If there are extra keys we display a warning suggesting to remove them.

e.g.
```
"dependencies.llvm.urlTemplate.linux": "..."
```
This is not needed anymore.

Fixes issue https://github.com/multiversx/mx-sdk-py-cli/issues/337.