### PR TITLE
Throw error if Rust is not installed for contract operations: new, build, clean

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -42,6 +42,7 @@ jobs:
         shell: bash
         run: |
           python3 -m multiversx_sdk_cli.cli deps install testwallets
+          python3 -m multiversx_sdk_cli.cli deps install rust
       - name: Run unit tests
         shell: bash
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,7 @@ jobs:
       - name: Setup test dependencies
         run: |
           python3 -m multiversx_sdk_cli.cli deps install testwallets
+          python3 -m multiversx_sdk_cli.cli deps install rust
       - name: Run unit tests
         run: |
           export PYTHONPATH=.

--- a/multiversx_sdk_cli/cli_contracts.py
+++ b/multiversx_sdk_cli/cli_contracts.py
@@ -15,6 +15,7 @@ from multiversx_sdk_cli.contract_verification import \
     trigger_contract_verification
 from multiversx_sdk_cli.contracts import SmartContract, query_contract
 from multiversx_sdk_cli.cosign_transaction import cosign_transaction
+from multiversx_sdk_cli.dependency_checker import check_if_rust_is_installed
 from multiversx_sdk_cli.docker import is_docker_installed, run_docker
 from multiversx_sdk_cli.errors import DockerMissingError, NoWalletProvided
 from multiversx_sdk_cli.interfaces import IAddress
@@ -279,11 +280,13 @@ def get_project_paths(args: Any) -> List[Path]:
 
 
 def clean(args: Any):
+    check_if_rust_is_installed()
     project_path = args.path
     projects.clean_project(Path(project_path))
 
 
 def build(args: Any):
+    check_if_rust_is_installed()
     project_paths = [Path(args.path)]
     arg_list = cli_shared.convert_args_object_to_args_list(args)
 
@@ -292,11 +295,13 @@ def build(args: Any):
 
 
 def do_report(args: Any):
+    check_if_rust_is_installed()
     args_dict = args.__dict__
     projects.do_report(args, args_dict)
 
 
 def run_tests(args: Any):
+    check_if_rust_is_installed()
     project_paths = get_project_paths(args)
     for project in project_paths:
         projects.run_tests(project, args)

--- a/multiversx_sdk_cli/dependency_checker.py
+++ b/multiversx_sdk_cli/dependency_checker.py
@@ -1,0 +1,11 @@
+from multiversx_sdk_cli import config, errors, ux
+from multiversx_sdk_cli.dependencies.modules import Rust
+
+
+def check_if_rust_is_installed():
+    RUST_MODULE_KEY = "rust"
+    rust_module = Rust(RUST_MODULE_KEY)
+    if not rust_module.is_installed(""):
+        tag = config.get_dependency_tag(RUST_MODULE_KEY)
+        ux.show_critical_error("Rust is not installed on your machine. Run `mxpy deps install rust --overwrite` and try again.")
+        raise errors.DependencyMissing(RUST_MODULE_KEY, tag)

--- a/multiversx_sdk_cli/projects/templates.py
+++ b/multiversx_sdk_cli/projects/templates.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import List, Union
 
 from multiversx_sdk_cli import myprocess
-from multiversx_sdk_cli.dependencies.install import install_module
+from multiversx_sdk_cli.dependency_checker import check_if_rust_is_installed
 
 logger = logging.getLogger("projects.templates")
 
@@ -33,7 +33,7 @@ class Contract:
 
     def _ensure_dependencies_installed(self):
         logger.info("Checking if the necessarry dependencies are installed.")
-        install_module("rust")
+        check_if_rust_is_installed()
 
     def _prepare_args_to_list_templates(self) -> List[str]:
         args = ["sc-meta", "templates"]


### PR DESCRIPTION
Previously, if one tried to build a contract using `mxpy` and it did not have Rust installed, `mxpy` would install it on the spot. Now, it does not install it anymore, it throws an error saying:
```sh
Rust is not installed on your machine. Please run `mxpy deps install rust --overwrite` and try again.
```

This was done  to make it easier for people to debug in case the installation failed. If `sc-meta`'s dependencies we're not installed it would fail the installation, but still proceed to try the contract build.

Fixes issue https://github.com/multiversx/mx-sdk-py-cli/issues/371.