### PR TITLE
Escape message when printing using rich

### DIFF
--- a/multiversx_sdk_cli/ux.py
+++ b/multiversx_sdk_cli/ux.py
@@ -1,14 +1,15 @@
 from rich import print
+from rich.markup import escape
 from rich.panel import Panel
 
 
 def show_message(message: str):
-    print(Panel(f"[green]{message}"))
+    print(Panel(f"[green]{escape(message)}"))
 
 
 def show_critical_error(message: str):
-    print(Panel(f"[red]{message}"))
+    print(Panel(f"[red]{escape(message)}"))
 
 
 def show_warning(message: str):
-    print(Panel(f"[yellow]{message}"))
+    print(Panel(f"[yellow]{escape(message)}"))


### PR DESCRIPTION
We used to display messages that could contain paths that were formatted like: `[/home/...]` and `rich` would consider it a closing tag and it would throw an error like:
```
closing tag '[/home/...]' at position x doesn't match any open tag
```
This is now fixed by using `rich.markup.escape()`.