### PR TITLE
On reproducible builds, add support for packaging all source code of a Cargo workspace

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -476,6 +476,37 @@ options:
   --twiggy-dominators                             generate a twiggy dominators report after building
 
 ```
+### Contract.ReproducibleBuild
+
+
+```
+$ mxpy contract reproducible-build --help
+usage: mxpy contract reproducible-build [-h] ...
+
+Build a Smart Contract and get the same output as a previously built Smart Contract
+
+positional arguments:
+  project                              🗀 the project directory (default: current directory)
+
+options:
+  -h, --help                           show this help message and exit
+  --debug                              set debug flag (default: False)
+  --no-optimization                    bypass optimizations (for clang) (default: False)
+  --no-wasm-opt                        do not optimize wasm files after the build (default: False)
+  --cargo-target-dir CARGO_TARGET_DIR  for rust projects, forward the parameter to Cargo
+  --wasm-symbols                       for rust projects, does not strip the symbols from the wasm output. Useful for
+                                       analysing the bytecode. Creates larger wasm files. Avoid in production (default:
+                                       False)
+  --wasm-name WASM_NAME                for rust projects, optionally specify the name of the wasm bytecode output file
+  --wasm-suffix WASM_SUFFIX            for rust projects, optionally specify the suffix of the wasm bytecode output file
+  --docker-image DOCKER_IMAGE          the docker image tag used to build the contract
+  --package-whole-project-src          include all project files in *.source.json (default: False)
+  --contract CONTRACT                  relative path of the contract in the project
+  --no-docker-interactive
+  --no-docker-tty
+  --no-default-platform                do not set DOCKER_DEFAULT_PLATFORM environment variable to 'linux/amd64'
+
+```
 ## Group **Transactions**
 
 

--- a/CLI.md.sh
+++ b/CLI.md.sh
@@ -49,6 +49,7 @@ generate() {
     command "Contract.Upgrade" "contract upgrade"
     command "Contract.Query" "contract query"
     command "Contract.Report" "contract report"
+    command "Contract.ReproducibleBuild" "contract reproducible-build"
 
     group "Transactions" "tx"
     command "Transactions.New" "tx new"

--- a/multiversx_sdk_cli/cli_contracts.py
+++ b/multiversx_sdk_cli/cli_contracts.py
@@ -159,6 +159,7 @@ def setup_parser(args: List[str], subparsers: Any) -> Any:
     _add_build_options_args(sub)
     sub.add_argument("--docker-image", required=True, type=str,
                      help="the docker image tag used to build the contract")
+    sub.add_argument("--package-whole-project-src", action="store_true", default=False, help="include all project files in *.source.json (default: %(default)s)")
     sub.add_argument("--contract", type=str, help="relative path of the contract in the project")
     sub.add_argument("--no-docker-interactive", action="store_true", default=False)
     sub.add_argument("--no-docker-tty", action="store_true", default=False)
@@ -423,6 +424,7 @@ def do_reproducible_build(args: Any):
     project_path = args.project
     docker_image = args.docker_image
     contract_path = args.contract
+    package_whole_project_src = args.package_whole_project_src
     docker_interactive = not args.no_docker_interactive
     docker_tty = not args.no_docker_tty
     no_default_platform = args.no_default_platform
@@ -440,7 +442,17 @@ def do_reproducible_build(args: Any):
         raise DockerMissingError()
 
     logger.info("Starting the docker run...")
-    run_docker(docker_image, project_path, contract_path, output_path, no_wasm_opt, docker_interactive, docker_tty, no_default_platform)
+    run_docker(
+        docker_image,
+        project_path,
+        package_whole_project_src,
+        contract_path,
+        output_path,
+        no_wasm_opt,
+        docker_interactive,
+        docker_tty,
+        no_default_platform
+    )
 
     logger.info("Docker build ran successfully!")
     logger.info(f"Inspect summary of generated artifacts here: {artifacts_path}")

--- a/multiversx_sdk_cli/docker.py
+++ b/multiversx_sdk_cli/docker.py
@@ -25,6 +25,7 @@ def is_docker_installed():
 def run_docker(
         image: str,
         project_path: Path,
+        package_whole_project_src: bool,
         contract: str,
         output_path: Path,
         no_wasm_opt: bool,
@@ -55,6 +56,9 @@ def run_docker(
 
     if project_path:
         entrypoint_args.extend(["--project", "project"])
+
+    if package_whole_project_src:
+        entrypoint_args.append("--package-whole-project-src")
 
     if no_wasm_opt:
         entrypoint_args.append("--no-wasm-opt")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "multiversx-sdk-cli"
-version = "9.2.0"
+version = "9.2.1"
 authors = [
   { name="MultiversX" },
 ]


### PR DESCRIPTION
On `mxpy contract reproducible-build`, add new (optional) flag: `--package-whole-project-src`.