### PR TITLE
Update rust version & install sc-meta using `--locked`

### DIFF
--- a/multiversx_sdk_cli/config.py
+++ b/multiversx_sdk_cli/config.py
@@ -150,7 +150,7 @@ def get_defaults() -> Dict[str, Any]:
         "dependencies.vmtools.urlTemplate.linux": "https://github.com/multiversx/mx-chain-vm-go/archive/{TAG}.tar.gz",
         "dependencies.vmtools.urlTemplate.osx": "https://github.com/multiversx/mx-chain-vm-go/archive/{TAG}.tar.gz",
         "dependencies.vmtools.urlTemplate.windows": "https://github.com/multiversx/mx-chain-vm-go/archive/{TAG}.tar.gz",
-        "dependencies.rust.tag": "nightly-2023-05-26",
+        "dependencies.rust.tag": "nightly-2023-12-11",
         "dependencies.golang.resolution": "SDK",
         "dependencies.golang.tag": "go1.20.7",
         "dependencies.golang.urlTemplate.linux": "https://golang.org/dl/{TAG}.linux-amd64.tar.gz",

--- a/multiversx_sdk_cli/dependencies/modules.py
+++ b/multiversx_sdk_cli/dependencies/modules.py
@@ -336,7 +336,7 @@ This may cause problems with the installation of rust.""")
     def _install_sc_meta(self):
         logger.info("Installing multiversx-sc-meta.")
         tag = config.get_dependency_tag("sc-meta")
-        args = ["cargo", "install", "multiversx-sc-meta"]
+        args = ["cargo", "install", "multiversx-sc-meta", "--locked"]
 
         if tag != "latest":
             args.extend(["--version", tag])


### PR DESCRIPTION
Update the Rust version that is being installed.
When `sc-meta` is installed the `--locked` argument is also passed.
Fixes https://github.com/multiversx/mx-sdk-py-cli/issues/383.