### PR TITLE
Fix dns register using relayed transaction

### DIFF
--- a/multiversx_sdk_cli/dns.py
+++ b/multiversx_sdk_cli/dns.py
@@ -7,8 +7,8 @@ from multiversx_sdk_cli import cli_shared, utils
 from multiversx_sdk_cli.accounts import Account
 from multiversx_sdk_cli.constants import ADDRESS_ZERO_BECH32, DEFAULT_HRP
 from multiversx_sdk_cli.contracts import query_contract
-from multiversx_sdk_cli.transactions import (
-    do_prepare_transaction, tx_to_dictionary_as_inner_for_relayed_V1)
+from multiversx_sdk_cli.transactions import (compute_relayed_v1_data,
+                                             do_prepare_transaction)
 
 MaxNumShards = 256
 ShardIdentiferLen = 2
@@ -50,7 +50,7 @@ def register(args: Any):
     tx = do_prepare_transaction(args)
 
     if hasattr(args, "relay") and args.relay:
-        args.outfile.write(tx_to_dictionary_as_inner_for_relayed_V1(tx))
+        args.outfile.write(compute_relayed_v1_data(tx))
         return
 
     cli_shared.send_or_simulate(tx, args)

--- a/multiversx_sdk_cli/tests/test_cli_dns.py
+++ b/multiversx_sdk_cli/tests/test_cli_dns.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+from multiversx_sdk_cli.cli import main
+
+testdata_path = Path(__file__).parent / "testdata"
+
+
+def test_prepare_relayed_dns_register_transaction():
+    alice = testdata_path / "alice.pem"
+
+    return_code = main([
+        "dns", "register",
+        "--pem", str(alice),
+        "--name", "alice.elrond",
+        "--nonce", "0",
+        "--gas-limit", "15000000",
+        "--chain", "T",
+        "--relay"
+    ])
+
+    assert False if return_code else True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "multiversx-sdk-cli"
-version = "9.2.0"
+version = "9.3.0"
 authors = [
   { name="MultiversX" },
 ]


### PR DESCRIPTION
Fixed the creation of relayed dns register transactions. It used to return the inner transaction as a `dict` instead of the data field for the relayed transaction .

Fixes https://github.com/multiversx/mx-sdk-py-cli/issues/386.