### PR TITLE
mxpy data parse: remove undesired warning message

### DIFF
--- a/multiversx_sdk_cli/cli.py
+++ b/multiversx_sdk_cli/cli.py
@@ -68,7 +68,10 @@ mxpy is part of the multiversx-sdk and consists of Command Line Tools and Python
 for interacting with the Blockchain (in general) and with Smart Contracts (in particular).
 
 mxpy targets a broad audience of users and developers.
-https://docs.multiversx.com/sdk-and-tools/mxpy.
+
+See:
+ - https://docs.multiversx.com/sdk-and-tools/sdk-py
+ - https://docs.multiversx.com/sdk-and-tools/sdk-py/mxpy-cli
         """,
         formatter_class=argparse.RawDescriptionHelpFormatter
     )

--- a/multiversx_sdk_cli/cli_data.py
+++ b/multiversx_sdk_cli/cli_data.py
@@ -37,8 +37,6 @@ def setup_parser(subparsers: Any) -> Any:
 
 
 def parse(args: Any):
-    logger.warning("Always review --expression parameters before executing this command!")
-
     file = Path(args.file).expanduser()
     expression: str = args.expression
     suffix = file.suffix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "multiversx-sdk-cli"
-version = "9.3.0"
+version = "9.3.1"
 authors = [
   { name="MultiversX" },
 ]


### PR DESCRIPTION
Fixes https://github.com/multiversx/mx-sdk-py-cli/issues/391.

The warning was added back when the `data parse` command was implemented. The message is not practical, and way too specific - it doesn't bring an additional value to the general advice: _never copy-paste and run scripts from untrusted sources_.

For the future, we should be careful about logging on commands whose STDOUT is consumed by downstream applications. Maybe we should even allow users to disable logging on certain commands.