### PR TITLE
Add shell completions

### DIFF
--- a/multiversx_sdk_cli/cli.py
+++ b/multiversx_sdk_cli/cli.py
@@ -1,9 +1,11 @@
+# PYTHON_ARGCOMPLETE_OK
 import argparse
 import logging
 import sys
 from argparse import ArgumentParser
 from typing import Any, List
 
+import argcomplete
 from rich.logging import RichHandler
 
 import multiversx_sdk_cli.cli_accounts
@@ -41,6 +43,7 @@ def _do_main(cli_args: List[str]):
     utils.ensure_folder(config.SDK_PATH)
     argv_with_config_args = config.add_config_args(cli_args)
     parser = setup_parser(argv_with_config_args)
+    argcomplete.autocomplete(parser)
     args = parser.parse_args(argv_with_config_args)
 
     if args.verbose:

--- a/multiversx_sdk_cli/cli.py
+++ b/multiversx_sdk_cli/cli.py
@@ -41,14 +41,10 @@ def main(cli_args: List[str] = sys.argv[1:]):
 
 def _do_main(cli_args: List[str]):
     utils.ensure_folder(config.SDK_PATH)
-    # argv_with_config_args = config.add_config_args(cli_args)
-    # parser = setup_parser(argv_with_config_args)
-    # argcomplete.autocomplete(parser)
-    # args = parser.parse_args(argv_with_config_args)
-
-    parser = setup_parser(cli_args)
+    argv_with_config_args = config.add_config_args(cli_args)
+    parser = setup_parser(argv_with_config_args)
     argcomplete.autocomplete(parser)
-    args = parser.parse_args(cli_args)
+    args = parser.parse_args(argv_with_config_args)
 
     if args.verbose:
         logging.basicConfig(level="DEBUG", force=True, format='%(name)s: %(message)s', handlers=[RichHandler(show_time=False, rich_tracebacks=True)])

--- a/multiversx_sdk_cli/cli.py
+++ b/multiversx_sdk_cli/cli.py
@@ -41,10 +41,14 @@ def main(cli_args: List[str] = sys.argv[1:]):
 
 def _do_main(cli_args: List[str]):
     utils.ensure_folder(config.SDK_PATH)
-    argv_with_config_args = config.add_config_args(cli_args)
-    parser = setup_parser(argv_with_config_args)
+    # argv_with_config_args = config.add_config_args(cli_args)
+    # parser = setup_parser(argv_with_config_args)
+    # argcomplete.autocomplete(parser)
+    # args = parser.parse_args(argv_with_config_args)
+
+    parser = setup_parser(cli_args)
     argcomplete.autocomplete(parser)
-    args = parser.parse_args(argv_with_config_args)
+    args = parser.parse_args(cli_args)
 
     if args.verbose:
         logging.basicConfig(level="DEBUG", force=True, format='%(name)s: %(message)s', handlers=[RichHandler(show_time=False, rich_tracebacks=True)])

--- a/multiversx_sdk_cli/config.py
+++ b/multiversx_sdk_cli/config.py
@@ -202,22 +202,9 @@ def add_config_args(argv: List[str]) -> List[str]:
     except KeyError:
         return argv
 
-    check_for_deprecated_args(config_args)
-
     final_args = determine_final_args(argv, config_args)
     print(f"Found extra arguments in mxpy.json. Final arguments: {final_args}")
     return final_args
-
-
-def check_for_deprecated_args(args: List[str]) -> None:
-    if "proxy" in args:
-        show_warning("Providing `proxy` in the configuration file is deprecated. It will not be used. Please remove it!")
-
-    if "chainID" in args:
-        show_warning("Providing `chainID` in the configuration file is deprecated. It will not be used. Please remove it!")
-
-    if "txVersion" in args:
-        show_warning("Providing `txVersion` in the configuration file is deprecated. It will not be used. Please remove it!")
 
 
 def determine_final_args(argv: List[str], config_args: Dict[str, Any]) -> List[str]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,8 @@ dependencies = [
   "rich==13.3.4",
   "multiversx-sdk-network-providers>=0.12.0,<0.13.0",
   "multiversx-sdk-wallet>=0.8.0,<0.9.0,",
-  "multiversx-sdk-core>=0.7.0,<0.8.0"
+  "multiversx-sdk-core>=0.7.0,<0.8.0",
+  "argcomplete"
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "multiversx-sdk-network-providers>=0.12.0,<0.13.0",
   "multiversx-sdk-wallet>=0.8.0,<0.9.0,",
   "multiversx-sdk-core>=0.7.0,<0.8.0",
-  "argcomplete"
+  "argcomplete==3.2.2"
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ ledgercomm[hid]
 semver
 requests-cache
 rich==13.3.4
+argcomplete
 
 multiversx-sdk-core>=0.7.0,<0.8.0
 multiversx-sdk-network-providers>=0.12.0,<0.13.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ ledgercomm[hid]
 semver
 requests-cache
 rich==13.3.4
-argcomplete
+argcomplete==3.2.2
 
 multiversx-sdk-core>=0.7.0,<0.8.0
 multiversx-sdk-network-providers>=0.12.0,<0.13.0


### PR DESCRIPTION
`mxpy` is now capable of shell completions using [argcomplete](https://kislyuk.github.io/argcomplete/). Keep in mind that `argcomplete` works only for `bash` and `zsh` shells.

After installing `mxpy` using `pipx` the following line needs to be added to your shell file. For `bash`, add it in the `.bashrc` file.
```sh
eval "$(register-python-argcomplete mxpy)"
```
Then, open a new terminal and enjoy autocompletions. Press `<Tab>` for completions and `<Tab><Tab>` to see all the options. Don't forget that for a more detailed look the `--help` or `-h` arguments can be used.

For reference: https://stackoverflow.com/questions/14597466/custom-tab-completion-in-python-argparse/15289025#15289025
Another alternative was to use [shtab](https://github.com/iterative/shtab).