### PR TITLE
Removed vmtools and contract test command

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -57,7 +57,7 @@ usage: mxpy contract COMMAND [-h] ...
 Build, deploy, upgrade and interact with Smart Contracts
 
 COMMANDS:
-  {new,templates,build,clean,test,report,deploy,call,upgrade,query,verify,reproducible-build}
+  {new,templates,build,clean,report,deploy,call,upgrade,query,verify,reproducible-build}
 
 OPTIONS:
   -h, --help            show this help message and exit
@@ -69,7 +69,6 @@ new                            Create a new Smart Contract project based on a te
 templates                      List the available Smart Contract templates.
 build                          Build a Smart Contract project.
 clean                          Clean a Smart Contract project.
-test                           Run scenarios (tests).
 report                         Print a detailed report of the smart contracts.
 deploy                         Deploy a Smart Contract.
 call                           Interact with a Smart Contract (execute function).
@@ -1263,11 +1262,11 @@ usage: mxpy deps install [-h] ...
 Install dependencies or multiversx-sdk modules.
 
 positional arguments:
-  {all,rust,golang,vmtools,testwallets}  the dependency to install
+  {all,rust,golang,testwallets}  the dependency to install
 
 options:
-  -h, --help                             show this help message and exit
-  --overwrite                            whether to overwrite an existing installation
+  -h, --help                     show this help message and exit
+  --overwrite                    whether to overwrite an existing installation
 
 ```
 ### Dependencies.Check
@@ -1280,10 +1279,10 @@ usage: mxpy deps check [-h] ...
 Check whether a dependency is installed.
 
 positional arguments:
-  {all,rust,golang,vmtools,testwallets}  the dependency to check
+  {all,rust,golang,testwallets}  the dependency to check
 
 options:
-  -h, --help                             show this help message and exit
+  -h, --help                     show this help message and exit
 
 ```
 ## Group **Configuration**

--- a/multiversx_sdk_cli/cli_contracts.py
+++ b/multiversx_sdk_cli/cli_contracts.py
@@ -53,14 +53,6 @@ def setup_parser(args: List[str], subparsers: Any) -> Any:
     sub.add_argument("--path", default=os.getcwd(), help="the project directory (default: current directory)")
     sub.set_defaults(func=clean)
 
-    sub = cli_shared.add_command_subparser(subparsers, "contract", "test", "Run scenarios (tests).")
-    _add_project_arg(sub)
-    sub.add_argument("--directory", default="scenarios",
-                     help="🗀 the directory containing the tests (default: %(default)s)")
-    sub.add_argument("--wildcard", required=False, help="wildcard to match only specific test files")
-    _add_recursive_arg(sub)
-    sub.set_defaults(func=run_tests)
-
     sub = cli_shared.add_command_subparser(subparsers, "contract", "report", "Print a detailed report of the smart contracts.")
     sub.add_argument("--skip-build", action="store_true", default=False, help="skips the step of building of the wasm contracts")
     sub.add_argument("--skip-twiggy", action="store_true", default=False, help="skips the steps of building the debug wasm files and running twiggy")
@@ -213,10 +205,6 @@ def _add_build_options_args(sub: Any):
                      help="for rust projects, optionally specify the suffix of the wasm bytecode output file")
 
 
-def _add_recursive_arg(sub: Any):
-    sub.add_argument("-r", "--recursive", dest="recursive", action="store_true", help="locate projects recursively")
-
-
 def _add_bytecode_arg(sub: Any):
     sub.add_argument("--bytecode", type=str, required=True,
                      help="the file containing the WASM bytecode")
@@ -298,13 +286,6 @@ def do_report(args: Any):
     check_if_rust_is_installed()
     args_dict = args.__dict__
     projects.do_report(args, args_dict)
-
-
-def run_tests(args: Any):
-    check_if_rust_is_installed()
-    project_paths = get_project_paths(args)
-    for project in project_paths:
-        projects.run_tests(project, args)
 
 
 def deploy(args: Any):

--- a/multiversx_sdk_cli/config.py
+++ b/multiversx_sdk_cli/config.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from typing import Any, Dict, List
 
 from multiversx_sdk_cli import errors, utils
-from multiversx_sdk_cli.ux import show_warning
 
 SDK_PATH = Path("~/multiversx-sdk").expanduser().resolve()
 LOCAL_CONFIG_PATH = Path("mxpy.json").resolve()
@@ -143,10 +142,6 @@ def _guard_valid_config_deletion(name: str):
 
 def get_defaults() -> Dict[str, Any]:
     return {
-        "dependencies.vmtools.tag": "v1.5.24",
-        "dependencies.vmtools.urlTemplate.linux": "https://github.com/multiversx/mx-chain-vm-go/archive/{TAG}.tar.gz",
-        "dependencies.vmtools.urlTemplate.osx": "https://github.com/multiversx/mx-chain-vm-go/archive/{TAG}.tar.gz",
-        "dependencies.vmtools.urlTemplate.windows": "https://github.com/multiversx/mx-chain-vm-go/archive/{TAG}.tar.gz",
         "dependencies.rust.tag": "nightly-2023-12-11",
         "dependencies.golang.resolution": "SDK",
         "dependencies.golang.tag": "go1.20.7",

--- a/multiversx_sdk_cli/dependencies/install.py
+++ b/multiversx_sdk_cli/dependencies/install.py
@@ -5,8 +5,7 @@ from typing import Dict, List
 from multiversx_sdk_cli import config, errors
 from multiversx_sdk_cli.dependencies.modules import (DependencyModule,
                                                      GolangModule, Rust,
-                                                     TestWalletsModule,
-                                                     VMToolsModule)
+                                                     TestWalletsModule)
 
 logger = logging.getLogger("install")
 
@@ -51,7 +50,6 @@ def get_all_deps() -> List[DependencyModule]:
     return [
         Rust(key="rust"),
         GolangModule(key="golang"),
-        VMToolsModule(key="vmtools"),
         TestWalletsModule(key="testwallets")
     ]
 

--- a/multiversx_sdk_cli/projects/__init__.py
+++ b/multiversx_sdk_cli/projects/__init__.py
@@ -1,8 +1,8 @@
 from multiversx_sdk_cli.projects.core import (build_project, clean_project,
-                                              load_project, run_tests)
+                                              load_project)
 from multiversx_sdk_cli.projects.project_base import Project
 from multiversx_sdk_cli.projects.project_rust import ProjectRust
 from multiversx_sdk_cli.projects.report.do_report import do_report
 from multiversx_sdk_cli.projects.templates import Contract
 
-__all__ = ["build_project", "clean_project", "do_report", "run_tests", "load_project", "Project", "ProjectRust", "Contract"]
+__all__ = ["build_project", "clean_project", "do_report", "load_project", "Project", "ProjectRust", "Contract"]

--- a/multiversx_sdk_cli/projects/core.py
+++ b/multiversx_sdk_cli/projects/core.py
@@ -1,8 +1,8 @@
 import logging
 from pathlib import Path
-from typing import Any, List
+from typing import List
 
-from multiversx_sdk_cli import dependencies, errors, guards
+from multiversx_sdk_cli import errors, guards
 from multiversx_sdk_cli.projects import shared
 from multiversx_sdk_cli.projects.constants import (OLD_PROJECT_CONFIG_FILENAME,
                                                    PROJECT_CONFIG_FILENAME)
@@ -40,19 +40,6 @@ def clean_project(directory: Path):
     project = load_project(directory)
     project.clean()
     logger.info("Project cleaned.")
-
-
-def run_tests(project_path: Path, args: Any):
-    directory = Path(args.directory)
-    wildcard = args.wildcard
-
-    logger.info("run_tests.project: %s", project_path)
-
-    dependencies.install_module("vmtools")
-
-    guards.is_directory(project_path)
-    project = load_project(project_path)
-    project.run_tests(directory, wildcard)
 
 
 def get_project_paths_recursively(base_path: Path) -> List[Path]:

--- a/multiversx_sdk_cli/projects/project_base.py
+++ b/multiversx_sdk_cli/projects/project_base.py
@@ -1,13 +1,11 @@
-import glob
 import logging
 import shutil
 from abc import abstractmethod
 from os import path
 from pathlib import Path
-from typing import Any, Dict, List, Union, cast, final
+from typing import Any, Dict, List, Union, final
 
-from multiversx_sdk_cli import dependencies, errors, myprocess, utils
-from multiversx_sdk_cli.dependencies.modules import StandaloneModule
+from multiversx_sdk_cli import dependencies, errors, utils
 from multiversx_sdk_cli.projects.constants import PROJECT_CONFIG_FILENAME
 from multiversx_sdk_cli.projects.interfaces import IProject
 from multiversx_sdk_cli.projects.migrations import migrate_project_config_file
@@ -128,24 +126,6 @@ class Project(IProject):
 
     def default_config(self) -> Dict[str, Any]:
         return dict()
-
-    def run_tests(self, tests_directory: Path, wildcard: str = ""):
-        vmtools = cast(StandaloneModule, dependencies.get_module_by_key("vmtools"))
-        tool_env = vmtools.get_env()
-        tool = path.join(vmtools.get_parent_directory(), "run-scenarios")
-        test_folder = self.directory / tests_directory
-
-        if not wildcard:
-            args = [tool, str(test_folder)]
-            myprocess.run_process(args, env=tool_env)
-        else:
-            pattern = test_folder / wildcard
-            test_files = glob.glob(str(pattern))
-
-            for test_file in test_files:
-                print("Run test for:", test_file)
-                args = [tool, test_file]
-                myprocess.run_process(args, env=tool_env)
 
 
 def glob_files(folder: Path, pattern: str) -> List[Path]:

--- a/multiversx_sdk_cli/tests/test_cli_contracts.sh
+++ b/multiversx_sdk_cli/tests/test_cli_contracts.sh
@@ -107,7 +107,6 @@ testAll() {
     testTrivialCommands || return 1
     testCreateContracts || return 1
     testBuildContracts || return 1
-    testRunScenarios || return 1
     testCleanContracts || return 1
     testWasmName || return 1
 }

--- a/multiversx_sdk_cli/tests/test_cli_contracts.sh
+++ b/multiversx_sdk_cli/tests/test_cli_contracts.sh
@@ -34,12 +34,6 @@ testBuildContracts() {
     assertFileExists ${SANDBOX}/empty/output/empty.abi.json || return 1
 }
 
-testRunScenarios() {
-    echo "testRunScenarios"
-    ${CLI} --verbose contract test --directory="scenarios" ${SANDBOX}/adder || return 1
-    ${CLI} --verbose contract test --directory="scenarios" ${SANDBOX}/empty || return 1
-}
-
 testWasmName() {
     echo "testWasmName"
    

--- a/multiversx_sdk_cli/tests/test_cli_deps.py
+++ b/multiversx_sdk_cli/tests/test_cli_deps.py
@@ -31,18 +31,6 @@ def test_deps_check_rust():
     assert which_twiggy and Path.is_file(Path(which_twiggy))
 
 
-@pytest.mark.skip_on_windows
-def test_deps_install_vmtools():
-    return_code = main(["deps", "install", "vmtools"])
-    assert return_code == 0
-
-
-@pytest.mark.skip_on_windows
-def test_deps_check_vmtools():
-    return_code = main(["deps", "check", "vmtools"])
-    assert return_code == 0
-
-
 def test_deps_install_testwallets():
     return_code = main(["deps", "install", "testwallets"])
     assert return_code == 0


### PR DESCRIPTION
`vmtools` is not needed anymore because `sc-meta` can now install all the required dependencies. It is now recommended to use `sc-meta` for creating, building and testing contracts and use `mxpy` to deploy, call and upgrade the contract.