### PR TITLE
Raise error when given string argument without prefix

### DIFF
--- a/multiversx_sdk_cli/cli_contracts.py
+++ b/multiversx_sdk_cli/cli_contracts.py
@@ -429,7 +429,7 @@ def query(args: Any):
 
     proxy = ProxyNetworkProvider(args.proxy)
     function = args.function
-    arguments = args.arguments or []
+    arguments: List[Any] = args.arguments or []
 
     result = query_contract(contract_address, proxy, function, arguments)
     utils.dump_out_json(result)

--- a/multiversx_sdk_cli/contracts.py
+++ b/multiversx_sdk_cli/contracts.py
@@ -280,6 +280,8 @@ def prepare_args_for_factory(arguments: List[str]) -> List[Any]:
             args.append(True)
         elif arg.startswith(STR_PREFIX):
             args.append(arg[len(STR_PREFIX):])
+        else:
+            raise errors.BadUserInput(f"Unknown argument type for argument: `{arg}`. Use `mxpy contract <sub-command> --help` to check all supported arguments")
 
     return args
 

--- a/multiversx_sdk_cli/tests/test_cli_contracts.py
+++ b/multiversx_sdk_cli/tests/test_cli_contracts.py
@@ -301,7 +301,7 @@ def test_contract_commands_argument_parameter():
         "--nonce", "7",
         "--chain", "D",
         "--gas-limit", "5000000",
-        "--arguments", "invalidargument",
+        "--arguments", "foobar",
     ])
     assert return_code
 
@@ -312,7 +312,7 @@ def test_contract_commands_argument_parameter():
         "--nonce", "7",
         "--chain", "D",
         "--gas-limit", "5000000",
-        "--arguments", "str:invalidargument",
+        "--arguments", "str:foobar",
     ])
     assert not return_code
 

--- a/multiversx_sdk_cli/tests/test_cli_contracts.py
+++ b/multiversx_sdk_cli/tests/test_cli_contracts.py
@@ -290,6 +290,33 @@ def test_contract_deploy_without_required_arguments():
     assert return_code
 
 
+def test_contract_commands_argument_parameter():
+    alice = f"{parent}/testdata/alice.pem"
+    adder = f"{parent}/testdata/adder.wasm"
+
+    return_code = main([
+        "contract", "deploy",
+        "--bytecode", adder,
+        "--pem", alice,
+        "--nonce", "7",
+        "--chain", "D",
+        "--gas-limit", "5000000",
+        "--arguments", "invalidargument",
+    ])
+    assert return_code
+
+    return_code = main([
+        "contract", "deploy",
+        "--bytecode", adder,
+        "--pem", alice,
+        "--nonce", "7",
+        "--chain", "D",
+        "--gas-limit", "5000000",
+        "--arguments", "str:invalidargument",
+    ])
+    assert not return_code
+
+
 def _read_stdout(capsys: Any) -> str:
     return capsys.readouterr().out.strip()
 

--- a/multiversx_sdk_cli/tests/test_cli_validators.sh
+++ b/multiversx_sdk_cli/tests/test_cli_validators.sh
@@ -7,38 +7,38 @@ testAll() {
     REWARD_ADDRESS="erd1k2s324ww2g0yj38qn2ch2jwctdy8mnfxep94q9arncc6xecg3xaq6mjse8"
 
     echo "Stake with recall nonce"
-    ${CLI} --verbose validator stake --pem="${USERS}/alice.pem" --value="2500${DENOMINATION}" --validators-file=./testdata/validators.json --reward-address=${REWARD_ADDRESS} --chain=${CHAIN_ID} --proxy=${PROXY} --estimate-gas --recall-nonce --send || return 1
+    ${CLI} --verbose validator stake --pem="${USERS}/alice.pem" --value="2500${DENOMINATION}" --validators-file=./testdata/validators.json --reward-address=${REWARD_ADDRESS} --chain=${CHAIN_ID} --proxy=${PROXY} --estimate-gas --recall-nonce || return 1
     echo "Stake with provided nonce"
     ${CLI} --verbose validator stake --pem="${USERS}/bob.pem" --value="2500${DENOMINATION}" --validators-file=./testdata/validators.json --reward-address=${REWARD_ADDRESS} --chain=${CHAIN_ID} --proxy=${PROXY} --estimate-gas --nonce=300 || return 1
 
 
     echo "Stake with topUP"
-    ${CLI} --verbose validator stake --top-up --pem="${USERS}/carol.pem" --value="2711${DENOMINATION}" --chain=${CHAIN_ID} --proxy=${PROXY} --estimate-gas --recall-nonce --send || return 1
+    ${CLI} --verbose validator stake --top-up --pem="${USERS}/carol.pem" --value="2711${DENOMINATION}" --chain=${CHAIN_ID} --proxy=${PROXY} --estimate-gas --recall-nonce || return 1
 
     echo "Unstake"
-    ${CLI} --verbose validator unstake --pem="${USERS}/dan.pem" --nodes-public-keys="${BLS_KEY}" --chain=${CHAIN_ID} --proxy=${PROXY} --estimate-gas --recall-nonce --send || return 1
+    ${CLI} --verbose validator unstake --pem="${USERS}/dan.pem" --nodes-public-keys="${BLS_KEY}" --chain=${CHAIN_ID} --proxy=${PROXY} --estimate-gas --recall-nonce || return 1
     echo "Unbond"
-    ${CLI} --verbose validator unbond --pem="${USERS}/eve.pem" --nodes-public-keys=${BLS_KEY} --chain=${CHAIN_ID} --proxy=${PROXY} --estimate-gas --recall-nonce --send || return 1
+    ${CLI} --verbose validator unbond --pem="${USERS}/eve.pem" --nodes-public-keys=${BLS_KEY} --chain=${CHAIN_ID} --proxy=${PROXY} --estimate-gas --recall-nonce || return 1
     echo "Unjail"
-    ${CLI} --verbose validator unjail --pem="${USERS}/frank.pem" --value="2500${DENOMINATION}" --nodes-public-keys=${BLS_KEY} --chain=${CHAIN_ID} --proxy=${PROXY} --estimate-gas --recall-nonce --send || return 1
+    ${CLI} --verbose validator unjail --pem="${USERS}/frank.pem" --value="2500${DENOMINATION}" --nodes-public-keys=${BLS_KEY} --chain=${CHAIN_ID} --proxy=${PROXY} --estimate-gas --recall-nonce || return 1
     echo "Change reward address"
-    ${CLI} --verbose validator change-reward-address --pem="${USERS}/grace.pem" --reward-address=${REWARD_ADDRESS} --chain=${CHAIN_ID} --proxy=${PROXY} --estimate-gas --recall-nonce --send || return 1
+    ${CLI} --verbose validator change-reward-address --pem="${USERS}/grace.pem" --reward-address=${REWARD_ADDRESS} --chain=${CHAIN_ID} --proxy=${PROXY} --estimate-gas --recall-nonce || return 1
 
     echo "UnstakeNodes"
-    ${CLI} --verbose validator unstake-nodes --pem="${USERS}/heidi.pem" --nodes-public-keys=${BLS_KEY} --chain=${CHAIN_ID} --proxy=${PROXY} --estimate-gas --recall-nonce --send || return 1
+    ${CLI} --verbose validator unstake-nodes --pem="${USERS}/heidi.pem" --nodes-public-keys=${BLS_KEY} --chain=${CHAIN_ID} --proxy=${PROXY} --estimate-gas --recall-nonce || return 1
 
     echo "UnstakeTokens"
-    ${CLI} --verbose validator unstake-tokens --pem="${USERS}/ivan.pem" --unstake-value="11${DENOMINATION}" --chain=${CHAIN_ID} --proxy=${PROXY} --estimate-gas --recall-nonce --send || return 1
+    ${CLI} --verbose validator unstake-tokens --pem="${USERS}/ivan.pem" --unstake-value="11${DENOMINATION}" --chain=${CHAIN_ID} --proxy=${PROXY} --estimate-gas --recall-nonce || return 1
 
     echo "UnbondNodes"
-    ${CLI} --verbose validator unbond-nodes --pem="${USERS}/judy.pem" --nodes-public-keys=${BLS_KEY} --chain=${CHAIN_ID} --proxy=${PROXY} --estimate-gas --recall-nonce --send || return 1
+    ${CLI} --verbose validator unbond-nodes --pem="${USERS}/judy.pem" --nodes-public-keys=${BLS_KEY} --chain=${CHAIN_ID} --proxy=${PROXY} --estimate-gas --recall-nonce || return 1
 
     echo "UnbondTokens"
-    ${CLI} --verbose validator unbond-tokens --pem="${USERS}/mallory.pem" --unbond-value="20${DENOMINATION}" --chain=${CHAIN_ID} --proxy=${PROXY} --estimate-gas --recall-nonce --send || return 1
+    ${CLI} --verbose validator unbond-tokens --pem="${USERS}/mallory.pem" --unbond-value="20${DENOMINATION}" --chain=${CHAIN_ID} --proxy=${PROXY} --estimate-gas --recall-nonce || return 1
 
     echo "CleanRegistrationData"
-    ${CLI} --verbose validator clean-registered-data --pem="${USERS}/mike.pem" --chain=${CHAIN_ID} --proxy=${PROXY} --estimate-gas --recall-nonce --send || return 1
+    ${CLI} --verbose validator clean-registered-data --pem="${USERS}/mike.pem" --chain=${CHAIN_ID} --proxy=${PROXY} --estimate-gas --recall-nonce || return 1
 
     echo "ReStakeUnstakedNodes"
-    ${CLI} --verbose validator restake-unstaked-nodes --pem="${USERS}/alice.pem" --nodes-public-keys=${BLS_KEY} --chain=${CHAIN_ID} --proxy=${PROXY} --estimate-gas --recall-nonce --send || return 1
+    ${CLI} --verbose validator restake-unstaked-nodes --pem="${USERS}/alice.pem" --nodes-public-keys=${BLS_KEY} --chain=${CHAIN_ID} --proxy=${PROXY} --estimate-gas --recall-nonce || return 1
 }


### PR DESCRIPTION
The `mxpy contract` sub-commands now raise an error if a `string` argument was provided without the `str:` prefix.