### PR TITLE
Fix transaction signing

### DIFF
--- a/multiversx_sdk_cli/accounts.py
+++ b/multiversx_sdk_cli/accounts.py
@@ -72,6 +72,9 @@ class Account(AccountBase):
         assert self.signer is not None
 
         transaction_computer = TransactionComputer()
+        if transaction.options & TX_HASH_SIGN_OPTIONS == TX_HASH_SIGN_OPTIONS:
+            return self.signer.sign(transaction_computer.compute_hash_for_signing(transaction)).hex()
+
         return self.signer.sign(transaction_computer.compute_bytes_for_signing(transaction)).hex()
 
     def sign_message(self, data: bytes) -> str:
@@ -96,7 +99,7 @@ class LedgerAccount(Account):
         should_use_hash_signing = compare_versions(ledger_version, SIGN_USING_HASH_VERSION) >= 0
         if should_use_hash_signing:
             transaction.version = TX_HASH_SIGN_VERSION
-            transaction.options = TX_HASH_SIGN_OPTIONS
+            transaction.options = transaction.options | TX_HASH_SIGN_OPTIONS
 
         transaction_computer = TransactionComputer()
 

--- a/multiversx_sdk_cli/cli_shared.py
+++ b/multiversx_sdk_cli/cli_shared.py
@@ -246,7 +246,7 @@ def should_sign_with_guardian_key(args: Any) -> bool:
 
 def check_options_for_guarded_tx(options: int):
     if not options & TRANSACTION_OPTIONS_TX_GUARDED == TRANSACTION_OPTIONS_TX_GUARDED:
-        raise errors.BadUsage("Invalid guarded transaction's options. The second least significant bit must be set.")
+        raise errors.BadUsage("Invalid guarded transaction's options. The second least significant bit must be set")
 
 
 def send_or_simulate(tx: ITransaction, args: Any, dump_output: bool = True) -> CLIOutputBuilder:

--- a/multiversx_sdk_cli/interfaces.py
+++ b/multiversx_sdk_cli/interfaces.py
@@ -15,7 +15,7 @@ class ITransaction(Protocol):
     gas_limit: int
     chain_id: str
     nonce: int
-    amount: int
+    value: int
     sender_username: str
     receiver_username: str
     gas_price: int

--- a/multiversx_sdk_cli/tests/test_cli_transactions.py
+++ b/multiversx_sdk_cli/tests/test_cli_transactions.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 from typing import Any
 
@@ -26,6 +27,25 @@ def test_relayed_v1_transaction(capsys: Any):
 
     relayed_tx = _read_stdout(capsys)
     assert relayed_tx == "relayedTx@7b226e6f6e6365223a3139382c2273656e646572223a2267456e574f65576d6d413063306a6b71764d354241707a61644b46574e534f69417643575163776d4750673d222c227265636569766572223a22414141414141414141414141415141414141414141414141414141414141414141414141414141432f2f383d222c2276616c7565223a302c226761735072696365223a313030303030303030302c226761734c696d6974223a36303030303030302c2264617461223a225a3256305132397564484a68593352446232356d6157633d222c227369676e6174757265223a2239682b6e6742584f5536776674315464437368534d4b3454446a5a32794f74686336564c576e3478724d5a706248427738677a6c6659596d362b766b505258303764634a562b4745635462616a7049692b5a5a5942773d3d222c22636861696e4944223a2256413d3d222c2276657273696f6e223a317d"
+
+
+def test_create_tx_and_sign_by_hash(capsys: Any):
+    return_code = main([
+        "tx", "new",
+        "--pem", str(testdata_path / "alice.pem"),
+        "--receiver", "erd1spyavw0956vq68xj8y4tenjpq2wd5a9p2c6j8gsz7ztyrnpxrruqzu66jx",
+        "--nonce", "89",
+        "--gas-limit", "50000",
+        "--version", "2",
+        "--options", "1",
+        "--chain", "integration tests chain ID",
+    ])
+    assert False if return_code else True
+
+    tx = _read_stdout(capsys)
+    tx_json = json.loads(tx)
+    signature = tx_json["emittedTransaction"]["signature"]
+    assert signature == "f0c81f2393b1ec5972c813f817bae8daa00ade91c6f75ea604ab6a4d2797aca4378d783023ff98f1a02717fe4f24240cdfba0b674ee9abb18042203d713bc70a"
 
 
 def _read_stdout(capsys: Any) -> str:

--- a/multiversx_sdk_cli/transactions.py
+++ b/multiversx_sdk_cli/transactions.py
@@ -74,7 +74,7 @@ def do_prepare_transaction(args: Any) -> Transaction:
         gas_price=int(args.gas_price),
         data=str(args.data).encode(),
         nonce=int(args.nonce),
-        amount=int(args.value),
+        value=int(args.value),
         version=int(args.version),
         options=int(args.options)
     )
@@ -150,7 +150,7 @@ def tx_to_dictionary_as_inner_for_relayed_V1(tx: Transaction) -> Dict[str, Any]:
     dictionary["nonce"] = tx.nonce
     dictionary["sender"] = base64.b64encode(Address.new_from_bech32(tx.sender).get_public_key()).decode()
     dictionary["receiver"] = base64.b64encode(Address.new_from_bech32(tx.receiver).get_public_key()).decode()
-    dictionary["value"] = tx.amount
+    dictionary["value"] = tx.value
     dictionary["gasPrice"] = tx.gas_price
     dictionary["gasLimit"] = tx.gas_limit
     dictionary["data"] = base64.b64encode(tx.data).decode()
@@ -204,7 +204,7 @@ def load_transaction_from_file(f: TextIO) -> Transaction:
         receiver_username=decode_field_value(instance.receiverUsername),
         gas_limit=instance.gasLimit,
         gas_price=instance.gasPrice,
-        amount=int(instance.value),
+        value=int(instance.value),
         data=TransactionPayload.from_encoded_str(instance.data).data,
         version=instance.version,
         options=instance.options,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "multiversx-sdk-cli"
-version = "9.5.3"
+version = "9.5.4"
 authors = [
   { name="MultiversX" },
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,6 @@ semver
 requests-cache
 rich==13.3.4
 
-multiversx-sdk-core>=0.7.0,<0.8.0
-multiversx-sdk-network-providers>=0.12.0,<0.13.0
-multiversx-sdk-wallet>=0.8.0,<0.9.0
+multiversx-sdk-core>=0.8.0,<0.9.0
+multiversx-sdk-network-providers>=0.13.0,<0.14.0
+multiversx-sdk-wallet>=0.9.0,<0.10.0


### PR DESCRIPTION
There was an issue when signing transactions by hash (happened with a Ledger device).
Now the signing is done based on the `options` field in the transaction.

Also updated the dependencies.