### PR TITLE
Localnet: compatibility with Node 1.7 (Vega)

### DIFF
--- a/multiversx_sdk_cli/localnet/genesis.py
+++ b/multiversx_sdk_cli/localnet/genesis.py
@@ -1,6 +1,3 @@
-from multiversx_sdk_core.address import Address, AddressComputer
-
-from multiversx_sdk_cli.constants import NUMBER_OF_SHARDS
 from multiversx_sdk_cli.localnet import wallets
 
 
@@ -9,18 +6,5 @@ def get_owner_of_genesis_contracts():
     return users["alice"]
 
 
-def get_delegation_address() -> Address:
-    owner = get_owner_of_genesis_contracts()
-    owner.nonce = 0
-
-    address_computer = AddressComputer(NUMBER_OF_SHARDS)
-    address = address_computer.compute_contract_address(owner.address, owner.nonce)
-    return address
-
-
 def is_last_user(nickname: str) -> bool:
     return nickname == "mike"
-
-
-def is_foundational_node(nickname: str) -> bool:
-    return nickname == "validator00"

--- a/multiversx_sdk_cli/localnet/genesis_json.py
+++ b/multiversx_sdk_cli/localnet/genesis_json.py
@@ -1,13 +1,9 @@
 from typing import Any, Dict, List
 
-from multiversx_sdk_core import Address
-
 from multiversx_sdk_cli.accounts import Account
 from multiversx_sdk_cli.localnet import wallets
 from multiversx_sdk_cli.localnet.config_root import ConfigRoot
-from multiversx_sdk_cli.localnet.genesis import (get_delegation_address,
-                                                 is_foundational_node,
-                                                 is_last_user)
+from multiversx_sdk_cli.localnet.genesis import is_last_user
 
 ENTIRE_SUPPLY = 20000000000000000000000000
 # For localnet, we delegate for 1 node
@@ -18,13 +14,8 @@ def build(config: ConfigRoot) -> List[Any]:
     num_validators = config.num_all_validators()
     genesis_items: List[Dict[str, Any]] = []
     remaining_supply = ENTIRE_SUPPLY
-    remaining_to_delegate = DELEGATED_VALUE
-    delegation_address = get_delegation_address()
 
     for nickname, account in wallets.get_validator_wallets(num_validators).items():
-        if is_foundational_node(nickname):
-            continue
-
         value = 2500000000000000000000
         entry = _build_validator_entry(nickname, account, value)
         genesis_items.append(entry)
@@ -33,11 +24,9 @@ def build(config: ConfigRoot) -> List[Any]:
     for nickname, account in wallets.get_users().items():
         # The last user (mike) gets all remaining tokens
         value = remaining_supply if is_last_user(nickname) else 100000000000000000000000
-        delegated_value = remaining_to_delegate if is_last_user(nickname) else 100000000000000000000
-        entry = _build_user_entry(nickname, account, value, delegated_value, delegation_address)
+        entry = _build_user_entry(nickname, account, value)
         genesis_items.append(entry)
         remaining_supply -= value
-        remaining_to_delegate -= delegated_value
 
     return genesis_items
 
@@ -56,15 +45,15 @@ def _build_validator_entry(nickname: str, account: Account, value: int) -> Dict[
     }
 
 
-def _build_user_entry(nickname: str, account: Account, value: int, delegated_value: int, delegation_address: Address) -> Dict[str, Any]:
+def _build_user_entry(nickname: str, account: Account, value: int) -> Dict[str, Any]:
     return {
         "nickname": nickname,
         "address": account.address.to_bech32(),
         "supply": str(value),
-        "balance": str(value - delegated_value),
+        "balance": str(value),
         "stakingvalue": "0",
         "delegation": {
-            "address": delegation_address.to_bech32(),
-            "value": str(delegated_value)
+            "address": "",
+            "value": "0"
         }
     }

--- a/multiversx_sdk_cli/localnet/node_config_toml.py
+++ b/multiversx_sdk_cli/localnet/node_config_toml.py
@@ -43,8 +43,28 @@ def patch_api(data: ConfigDict, config: ConfigRoot):
 
 
 def patch_enable_epochs(data: ConfigDict, config: ConfigRoot):
-    max_nodes_change_enable_epoch = data["EnableEpochs"]["MaxNodesChangeEnableEpoch"]
+    enable_epochs = data["EnableEpochs"]
+    enable_epochs['SCDeployEnableEpoch'] = 0
+    enable_epochs['BuiltInFunctionsEnableEpoch'] = 0
+    enable_epochs['RelayedTransactionsEnableEpoch'] = 0
+    enable_epochs['PenalizedTooMuchGasEnableEpoch'] = 0
+    enable_epochs['AheadOfTimeGasUsageEnableEpoch'] = 0
+    enable_epochs['GasPriceModifierEnableEpoch'] = 0
+    enable_epochs['RepairCallbackEnableEpoch'] = 0
+    enable_epochs['ReturnDataToLastTransferEnableEpoch'] = 0
+    enable_epochs['SenderInOutTransferEnableEpoch'] = 0
+    enable_epochs['ESDTEnableEpoch'] = 0
+    enable_epochs['IncrementSCRNonceInMultiTransferEnableEpoch'] = 0
+    enable_epochs['ESDTMultiTransferEnableEpoch'] = 0
+    enable_epochs['GlobalMintBurnDisableEpoch'] = 0
+    enable_epochs['ESDTTransferRoleEnableEpoch'] = 0
+    enable_epochs['BuiltInFunctionOnMetaEnableEpoch'] = 0
+    enable_epochs['MultiESDTTransferFixOnCallBackOnEnableEpoch'] = 0
+    enable_epochs['ESDTNFTCreateOnMultiShard'] = 0
+    enable_epochs['MetaESDTSetEnableEpoch'] = 0
+    enable_epochs['DelegationManagerEnableEpoch'] = 0
+
+    max_nodes_change_enable_epoch = enable_epochs['MaxNodesChangeEnableEpoch']
     last_entry = max_nodes_change_enable_epoch[-1]
     penultimate_entry = max_nodes_change_enable_epoch[-2]
-    last_entry["MaxNumNodes"] = penultimate_entry["MaxNumNodes"] - (config.shards.num_shards + 1) * penultimate_entry["NodesToShufflePerShard"]
-    
+    last_entry['MaxNumNodes'] = penultimate_entry['MaxNumNodes'] - (config.shards.num_shards + 1) * penultimate_entry['NodesToShufflePerShard']

--- a/multiversx_sdk_cli/localnet/node_config_toml.py
+++ b/multiversx_sdk_cli/localnet/node_config_toml.py
@@ -7,14 +7,16 @@ ConfigDict = Dict[str, Any]
 
 
 def patch_config(data: ConfigDict, config: ConfigRoot):
+    data['GeneralSettings']['ChainID'] = CHAIN_ID
+
+    # "--operation-mode=historical-balances" is not available for nodes,
+    # since << validator cannot be a full archive node >>,
+    # but we attempt to set the "deep-history" mode as follows:
     data['DbLookupExtensions']['Enabled'] = True
-
-    general_settings: ConfigDict = dict()
-    general_settings['ChainID'] = CHAIN_ID
-    general_settings['StartInEpochEnabled'] = False
-    general_settings['SetGuardianEpochsDelay'] = 1
-
-    data['GeneralSettings'].update(general_settings)
+    data['GeneralSettings']['StartInEpochEnabled'] = False
+    data['StateTriesConfig']['AccountsStatePruningEnabled'] = False
+    data['StoragePruning']['ObserverCleanOldEpochsData'] = False
+    data['StoragePruning']['AccountsTrieCleanOldEpochsData'] = False
 
     # Make epochs shorter
     epoch_start_config: ConfigDict = dict()
@@ -41,31 +43,8 @@ def patch_api(data: ConfigDict, config: ConfigRoot):
 
 
 def patch_enable_epochs(data: ConfigDict, config: ConfigRoot):
-    enable_epochs: ConfigDict = dict()
-    enable_epochs['SCDeployEnableEpoch'] = 0
-    enable_epochs['BuiltInFunctionsEnableEpoch'] = 0
-    enable_epochs['RelayedTransactionsEnableEpoch'] = 0
-    enable_epochs['PenalizedTooMuchGasEnableEpoch'] = 0
-    enable_epochs['SwitchJailWaitingEnableEpoch'] = 0
-    enable_epochs['BelowSignedThresholdEnableEpoch'] = 0
-    enable_epochs['AheadOfTimeGasUsageEnableEpoch'] = 0
-    enable_epochs['GasPriceModifierEnableEpoch'] = 0
-    enable_epochs['RepairCallbackEnableEpoch'] = 0
-    enable_epochs['BlockGasAndFeesReCheckEnableEpoch'] = 0
-    enable_epochs['ReturnDataToLastTransferEnableEpoch'] = 0
-    enable_epochs['SenderInOutTransferEnableEpoch'] = 0
-    enable_epochs['ESDTEnableEpoch'] = 0
-    enable_epochs['IncrementSCRNonceInMultiTransferEnableEpoch'] = 0
-    enable_epochs['ESDTMultiTransferEnableEpoch'] = 0
-    enable_epochs['GlobalMintBurnDisableEpoch'] = 0
-    enable_epochs['ESDTTransferRoleEnableEpoch'] = 0
-    enable_epochs['BuiltInFunctionOnMetaEnableEpoch'] = 0
-    enable_epochs['MultiESDTTransferFixOnCallBackOnEnableEpoch'] = 0
-    enable_epochs['ESDTNFTCreateOnMultiShard'] = 0
-    enable_epochs['RemoveNonUpdatedStorageEnableEpoch'] = 0
-    enable_epochs['FixOOGReturnCodeEnableEpoch'] = 0
-    enable_epochs['CorrectFirstQueuedEpoch'] = 0
-    enable_epochs['MetaESDTSetEnableEpoch'] = 0
-    enable_epochs['DelegationManagerEnableEpoch'] = 0
-
-    data['EnableEpochs'].update(enable_epochs)
+    max_nodes_change_enable_epoch = data["EnableEpochs"]["MaxNodesChangeEnableEpoch"]
+    last_entry = max_nodes_change_enable_epoch[-1]
+    penultimate_entry = max_nodes_change_enable_epoch[-2]
+    last_entry["MaxNumNodes"] = penultimate_entry["MaxNumNodes"] - (config.shards.num_shards + 1) * penultimate_entry["NodesToShufflePerShard"]
+    

--- a/multiversx_sdk_cli/localnet/nodes_setup_json.py
+++ b/multiversx_sdk_cli/localnet/nodes_setup_json.py
@@ -1,10 +1,7 @@
 from typing import Any, Dict, List
 
-from multiversx_sdk_cli.accounts import Account
 from multiversx_sdk_cli.localnet import wallets
 from multiversx_sdk_cli.localnet.config_root import ConfigRoot
-from multiversx_sdk_cli.localnet.genesis import (get_delegation_address,
-                                                 is_foundational_node)
 
 CHAIN_ID = "localnet"
 
@@ -14,7 +11,12 @@ def build(config: ConfigRoot) -> Any:
     initial_nodes: List[Dict[str, str]] = []
 
     for nickname, [pubkey, account] in wallets.get_validators(num_validators).items():
-        entry = _build_initial_nodes_entry(nickname, pubkey, account)
+        entry = {
+            "nickname": nickname,
+            "address": account.address.to_bech32(),
+            "pubkey": pubkey,
+        }
+
         initial_nodes.append(entry)
 
     # Then, patch the list of initial nodes, so that higher indexes will become metachain nodes.
@@ -34,14 +36,4 @@ def build(config: ConfigRoot) -> Any:
         "chainID": CHAIN_ID,
         "minTransactionVersion": 1,
         "initialNodes": initial_nodes
-    }
-
-
-def _build_initial_nodes_entry(nickname: str, pubkey: str, account: Account) -> Dict[str, str]:
-    address = get_delegation_address().bech32() if is_foundational_node(nickname) else account.address.bech32()
-
-    return {
-        "nickname": nickname,
-        "address": address,
-        "pubkey": pubkey,
     }

--- a/multiversx_sdk_cli/localnet/step_start.py
+++ b/multiversx_sdk_cli/localnet/step_start.py
@@ -63,7 +63,8 @@ async def do_start(configfile: Path, stop_after_seconds: int):
             f"--log-level={loglevel}",
             "--log-logger-name",
             f"--destination-shard-as-observer={observer.shard}",
-            f"--rest-api-interface={observer.api_interface()}"
+            f"--rest-api-interface={observer.api_interface()}",
+            "--operation-mode=historical-balances"
         ], cwd=observer.folder, delay=NODES_START_DELAY))
 
     # Validators

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "multiversx-sdk-cli"
-version = "9.5.5"
+version = "9.6.0"
 authors = [
   { name="MultiversX" },
 ]


### PR DESCRIPTION
Make `mxpy localnet` compatible with [Vega release](https://multiversx.com/release/release-vega-v1-7-10).

## Simplification of `genesis.json`: no more legacy delegation

Simplification - no more legacy delegation. E.g. (excerpt from `genesis.json`):

```
{
        "nickname": "alice",
        "address": "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th",
        "supply": "100000000000000000000000",
        "balance": "100000000000000000000000",
        "stakingvalue": "0",
        "delegation": {
            "address": "",
            "value": "0"
        }
    },
```

## Simplification of config patching - `enableEpochs.toml` 

Simplification - `enableEpochs.toml` entries are only minimally adjusted now (they were heavily adjusted before). All feature flags now correspond to: [`enableEpochs.toml`](https://github.com/multiversx/mx-chain-go/blob/master/cmd/node/config/enableEpochs.toml).

Some implications (can lead to breaking changes in using `mxpy localnet`):
 - `SCDeployEnableEpoch` is 1 (default of mx-chain-go repository) instead of 0 (previous default in mxpy)
 - `ESDTEnableEpoch` is 1 (default of mx-chain-go repository) instead of 0 (previous default in mxpy)
 - etc.