### PR TITLE
By default, install rust "stable"

### DIFF
--- a/multiversx_sdk_cli/config.py
+++ b/multiversx_sdk_cli/config.py
@@ -147,7 +147,7 @@ def get_defaults() -> Dict[str, Any]:
         "dependencies.vmtools.urlTemplate.linux": "https://github.com/multiversx/mx-chain-vm-go/archive/{TAG}.tar.gz",
         "dependencies.vmtools.urlTemplate.osx": "https://github.com/multiversx/mx-chain-vm-go/archive/{TAG}.tar.gz",
         "dependencies.vmtools.urlTemplate.windows": "https://github.com/multiversx/mx-chain-vm-go/archive/{TAG}.tar.gz",
-        "dependencies.rust.tag": "nightly-2023-12-11",
+        "dependencies.rust.tag": "stable",
         "dependencies.golang.resolution": "SDK",
         "dependencies.golang.tag": "go1.20.7",
         "dependencies.golang.urlTemplate.linux": "https://golang.org/dl/{TAG}.linux-amd64.tar.gz",

--- a/multiversx_sdk_cli/dependencies/modules.py
+++ b/multiversx_sdk_cli/dependencies/modules.py
@@ -325,7 +325,7 @@ This may cause problems with the installation of rust.""")
         if tag:
             toolchain = tag
         else:
-            toolchain = "nightly"
+            toolchain = "stable"
 
         args = [str(installer_path), "--verbose", "--default-toolchain", toolchain, "--profile",
                 "minimal", "--target", "wasm32-unknown-unknown", "-y"]

--- a/multiversx_sdk_cli/tests/shared.sh
+++ b/multiversx_sdk_cli/tests/shared.sh
@@ -16,7 +16,7 @@ PROXY="${PROXY:-http://localhost:7950}"
 CHAIN_ID="${CHAIN_ID:-localnet}"
 TestUser=./testdata/testUser.pem
 TestUser2=./testdata/testUser2.pem
-RUST_VERSION="nightly-2023-05-26"
+RUST_VERSION="stable"
 
 cleanSandbox() {
     rm -rf ${SANDBOX}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "multiversx-sdk-cli"
-version = "9.5.6"
+version = "9.6.0"
 authors = [
   { name="MultiversX" },
 ]


### PR DESCRIPTION
With respect to:
 - https://github.com/multiversx/mx-sdk-rs/blob/master/.github/workflows/actions.yml

Don't use a fixed version for the stable Rust - just use latest stable (same behavior as the default SC CI workflows).