### PR TITLE
Add support for esdt transfers

### DIFF
--- a/multiversx_sdk_cli/cli_transactions.py
+++ b/multiversx_sdk_cli/cli_transactions.py
@@ -17,6 +17,7 @@ def setup_parser(args: List[str], subparsers: Any) -> Any:
 
     sub = cli_shared.add_command_subparser(subparsers, "tx", "new", f"Create a new transaction.{CLIOutputBuilder.describe()}")
     _add_common_arguments(args, sub)
+    _add_token_transfers_args(sub)
     cli_shared.add_outfile_arg(sub, what="signed transaction, hash")
     cli_shared.add_broadcast_args(sub, relay=True)
     cli_shared.add_proxy_arg(sub)
@@ -59,6 +60,12 @@ def _add_common_arguments(args: List[str], sub: Any):
     cli_shared.add_wallet_args(args, sub)
     cli_shared.add_tx_args(args, sub, with_guardian=True)
     sub.add_argument("--data-file", type=str, default=None, help="a file containing transaction data")
+
+
+def _add_token_transfers_args(sub: Any):
+    sub.add_argument("--token-transfers", nargs='+',
+                     help="token transfers for transfer & execute, as [token, amount] "
+                     "E.g. --token-transfers NFT-123456-0a 1 ESDT-987654 100000000")
 
 
 def create_transaction(args: Any):

--- a/multiversx_sdk_cli/tests/test_cli_transactions.py
+++ b/multiversx_sdk_cli/tests/test_cli_transactions.py
@@ -23,7 +23,7 @@ def test_relayed_v1_transaction(capsys: Any):
         "--chain", "T",
         "--relay"
     ])
-    assert False if return_code else True
+    assert return_code == 0
 
     relayed_tx = _read_stdout(capsys)
     assert relayed_tx == "relayedTx@7b226e6f6e6365223a3139382c2273656e646572223a2267456e574f65576d6d413063306a6b71764d354241707a61644b46574e534f69417643575163776d4750673d222c227265636569766572223a22414141414141414141414141415141414141414141414141414141414141414141414141414141432f2f383d222c2276616c7565223a302c226761735072696365223a313030303030303030302c226761734c696d6974223a36303030303030302c2264617461223a225a3256305132397564484a68593352446232356d6157633d222c227369676e6174757265223a2239682b6e6742584f5536776674315464437368534d4b3454446a5a32794f74686336564c576e3478724d5a706248427738677a6c6659596d362b766b505258303764634a562b4745635462616a7049692b5a5a5942773d3d222c22636861696e4944223a2256413d3d222c2276657273696f6e223a317d"
@@ -40,7 +40,7 @@ def test_create_tx_and_sign_by_hash(capsys: Any):
         "--options", "1",
         "--chain", "integration tests chain ID",
     ])
-    assert False if return_code else True
+    assert return_code == 0
 
     tx = _read_stdout(capsys)
     tx_json = json.loads(tx)
@@ -61,7 +61,7 @@ def test_create_move_balance_transaction(capsys: Any):
         "--options", "0",
         "--chain", "T",
     ])
-    assert False if return_code else True
+    assert return_code == 0
     tx = _read_stdout(capsys)
     tx_json = json.loads(tx)
     signature = tx_json["emittedTransaction"]["signature"]
@@ -80,7 +80,7 @@ def test_create_multi_transfer_transaction(capsys: Any):
         "--options", "0",
         "--chain", "T",
     ])
-    assert False if return_code else True
+    assert return_code == 0
     tx = _read_stdout(capsys)
     tx_json = json.loads(tx)
     signature = tx_json["emittedTransaction"]["signature"]

--- a/multiversx_sdk_cli/tests/test_cli_transactions.py
+++ b/multiversx_sdk_cli/tests/test_cli_transactions.py
@@ -48,5 +48,44 @@ def test_create_tx_and_sign_by_hash(capsys: Any):
     assert signature == "f0c81f2393b1ec5972c813f817bae8daa00ade91c6f75ea604ab6a4d2797aca4378d783023ff98f1a02717fe4f24240cdfba0b674ee9abb18042203d713bc70a"
 
 
+def test_create_move_balance_transaction(capsys: Any):
+    return_code = main([
+        "tx", "new",
+        "--pem", str(testdata_path / "alice.pem"),
+        "--receiver", "erd1spyavw0956vq68xj8y4tenjpq2wd5a9p2c6j8gsz7ztyrnpxrruqzu66jx",
+        "--nonce", "215",
+        "--gas-limit", "500000",
+        "--value", "1000000000000",
+        "--data", "hello",
+        "--version", "2",
+        "--options", "0",
+        "--chain", "T",
+    ])
+    assert False if return_code else True
+    tx = _read_stdout(capsys)
+    tx_json = json.loads(tx)
+    signature = tx_json["emittedTransaction"]["signature"]
+    assert signature == "e88d846800bab1751e222c4461a310a3882312ef6d75fd8b861a2f3b572837b58f146ff9d60d16e617f53358d6cfa87cbcc65ad624c77003779d474059264901"
+
+
+def test_create_multi_transfer_transaction(capsys: Any):
+    return_code = main([
+        "tx", "new",
+        "--pem", str(testdata_path / "alice.pem"),
+        "--receiver", "erd1spyavw0956vq68xj8y4tenjpq2wd5a9p2c6j8gsz7ztyrnpxrruqzu66jx",
+        "--nonce", "212",
+        "--gas-limit", "5000000",
+        "--token-transfers", "SSSSS-941b91-01", "1", "TEST-738c3d", "1200000000",
+        "--version", "2",
+        "--options", "0",
+        "--chain", "T",
+    ])
+    assert False if return_code else True
+    tx = _read_stdout(capsys)
+    tx_json = json.loads(tx)
+    signature = tx_json["emittedTransaction"]["signature"]
+    assert signature == "575b029d52ff5ffbfb7bab2f04052de88a6f7d022a6ad368459b8af9acaed3717d3f95db09f460649a8f405800838bc2c432496bd03c9039ea166bd32b84660e"
+
+
 def _read_stdout(capsys: Any) -> str:
     return capsys.readouterr().out.strip()

--- a/multiversx_sdk_cli/transactions.py
+++ b/multiversx_sdk_cli/transactions.py
@@ -59,8 +59,8 @@ class JSONTransaction:
 
 def do_prepare_transaction(args: Any) -> Transaction:
     account = load_sender_account_from_args(args)
-    transfers = getattr(args, "token_transfers", None)
-    transfers = prepare_token_transfers(transfers) if transfers else None
+    transfers = getattr(args, "token_transfers", [])
+    transfers = prepare_token_transfers(transfers) if transfers else []
 
     config = TransactionsFactoryConfig(args.chain)
     factory = TransferTransactionsFactory(config)
@@ -112,7 +112,7 @@ def load_sender_account_from_args(args: Any) -> Account:
     return account
 
 
-def prepare_token_transfers(transfers: List[Any]):
+def prepare_token_transfers(transfers: List[Any]) -> List[TokenTransfer]:
     token_computer = TokenComputer()
     token_transfers: List[TokenTransfer] = []
 

--- a/multiversx_sdk_cli/transactions.py
+++ b/multiversx_sdk_cli/transactions.py
@@ -2,9 +2,12 @@ import base64
 import json
 import logging
 import time
-from typing import Any, Dict, Optional, Protocol, TextIO
+from typing import Any, Dict, List, Optional, Protocol, TextIO
 
-from multiversx_sdk import Address, Transaction, TransactionPayload
+from multiversx_sdk import (Address, Token, TokenComputer, TokenTransfer,
+                            Transaction, TransactionPayload,
+                            TransactionsFactoryConfig,
+                            TransferTransactionsFactory)
 
 from multiversx_sdk_cli import errors
 from multiversx_sdk_cli.accounts import Account, LedgerAccount
@@ -55,6 +58,48 @@ class JSONTransaction:
 
 
 def do_prepare_transaction(args: Any) -> Transaction:
+    account = load_sender_account_from_args(args)
+    transfers = getattr(args, "token_transfers", None)
+    transfers = prepare_token_transfers(transfers) if transfers else None
+
+    config = TransactionsFactoryConfig(args.chain)
+    factory = TransferTransactionsFactory(config)
+    receiver = Address.new_from_bech32(args.receiver)
+
+    # will be replaced with 'create_transaction_for_transfer'
+    if transfers:
+        tx = factory.create_transaction_for_esdt_token_transfer(
+            sender=account.address,
+            receiver=receiver,
+            token_transfers=transfers
+        )
+    else:
+        tx = factory.create_transaction_for_native_token_transfer(
+            sender=account.address,
+            receiver=receiver,
+            native_amount=int(args.value),
+            data=str(args.data)
+        )
+
+    tx.gas_limit = int(args.gas_limit)
+    tx.sender_username = getattr(args, "sender_username", None) or ""
+    tx.receiver_username = getattr(args, "receiver_username", None) or ""
+    tx.gas_price = int(args.gas_price)
+    tx.nonce = int(args.nonce)
+    tx.value = int(args.value)
+    tx.version = int(args.version)
+    tx.options = int(args.options)
+
+    if args.guardian:
+        tx.guardian = args.guardian
+
+    tx.signature = bytes.fromhex(account.sign_transaction(tx))
+    tx = sign_tx_by_guardian(args, tx)
+
+    return tx
+
+
+def load_sender_account_from_args(args: Any) -> Account:
     account = Account()
     if args.ledger:
         account = LedgerAccount(account_index=args.ledger_account_index, address_index=args.ledger_address_index)
@@ -64,28 +109,23 @@ def do_prepare_transaction(args: Any) -> Transaction:
         password = load_password(args)
         account = Account(key_file=args.keyfile, password=password)
 
-    tx = Transaction(
-        chain_id=args.chain,
-        sender=account.address.to_bech32(),
-        receiver=args.receiver,
-        gas_limit=int(args.gas_limit),
-        sender_username=getattr(args, "sender_username", ""),
-        receiver_username=getattr(args, "receiver_username", ""),
-        gas_price=int(args.gas_price),
-        data=str(args.data).encode(),
-        nonce=int(args.nonce),
-        value=int(args.value),
-        version=int(args.version),
-        options=int(args.options)
-    )
+    return account
 
-    if args.guardian:
-        tx.guardian = args.guardian
 
-    tx.signature = bytes.fromhex(account.sign_transaction(tx))
-    tx = sign_tx_by_guardian(args, tx)
+def prepare_token_transfers(transfers: List[Any]):
+    token_computer = TokenComputer()
+    token_transfers: List[TokenTransfer] = []
 
-    return tx
+    for i in range(0, len(transfers) - 1, 2):
+        identifier = transfers[i]
+        amount = int(transfers[i + 1])
+        nonce = token_computer.extract_nonce_from_extended_identifier(identifier)
+
+        token = Token(identifier, nonce)
+        transfer = TokenTransfer(token, amount)
+        token_transfers.append(transfer)
+
+    return token_transfers
 
 
 def sign_tx_by_guardian(args: Any, tx: Transaction) -> Transaction:


### PR DESCRIPTION
Previously, there was no easy option to send `esdts`. 

Added a new argument for `mxpy tx new`, called `--token-transfers`. Multiple tokens can be provided like `<identifier> <amount>`.

e.g:
```sh
mxpy tx new --token-transfers NFT-123456-01 1 ESDT-987654 100
```