### PR TITLE
Added suport for contract queries using abi file

### DIFF
--- a/multiversx_sdk_cli/cli_contracts.py
+++ b/multiversx_sdk_cli/cli_contracts.py
@@ -444,7 +444,7 @@ def upgrade(args: Any):
 def query(args: Any):
     logger.debug("query")
 
-    # workaround so we can use the function bellow to set chainID
+    # workaround so we can use the function below to set chainID
     args.chain = ""
     cli_shared.prepare_chain_id_in_args(args)
 

--- a/multiversx_sdk_cli/cli_contracts.py
+++ b/multiversx_sdk_cli/cli_contracts.py
@@ -452,7 +452,7 @@ def query(args: Any):
     abi = Abi.load(Path(args.abi)) if args.abi else None
     contract = SmartContract(config, abi)
 
-    arguments, args_from_file = _get_contract_arguments(args)
+    arguments, should_prepare_args = _get_contract_arguments(args)
     contract_address = Address.new_from_bech32(args.contract)
 
     proxy = ProxyNetworkProvider(args.proxy)
@@ -463,7 +463,7 @@ def query(args: Any):
         proxy=proxy,
         function=function,
         arguments=arguments,
-        args_from_file=args_from_file
+        should_prepare_args=should_prepare_args
     )
 
     utils.dump_out_json(result)

--- a/multiversx_sdk_cli/cli_contracts.py
+++ b/multiversx_sdk_cli/cli_contracts.py
@@ -13,7 +13,7 @@ from multiversx_sdk_cli.cli_output import CLIOutputBuilder
 from multiversx_sdk_cli.constants import NUMBER_OF_SHARDS
 from multiversx_sdk_cli.contract_verification import \
     trigger_contract_verification
-from multiversx_sdk_cli.contracts import SmartContract, query_contract
+from multiversx_sdk_cli.contracts import SmartContract
 from multiversx_sdk_cli.cosign_transaction import cosign_transaction
 from multiversx_sdk_cli.dependency_checker import check_if_rust_is_installed
 from multiversx_sdk_cli.docker import is_docker_installed, run_docker
@@ -132,6 +132,7 @@ def setup_parser(args: List[str], subparsers: Any) -> Any:
     sub = cli_shared.add_command_subparser(subparsers, "contract", "query",
                                            "Query a Smart Contract (call a pure function)")
     _add_contract_arg(sub)
+    _add_contract_abi_arg(sub)
     cli_shared.add_proxy_arg(sub)
     _add_function_arg(sub)
     _add_arguments_arg(sub)
@@ -443,17 +444,28 @@ def upgrade(args: Any):
 def query(args: Any):
     logger.debug("query")
 
-    # workaround so we can use the function bellow
+    # workaround so we can use the function bellow to set chainID
     args.chain = ""
     cli_shared.prepare_chain_id_in_args(args)
 
+    config = TransactionsFactoryConfig(args.chain)
+    abi = Abi.load(Path(args.abi)) if args.abi else None
+    contract = SmartContract(config, abi)
+
+    arguments, args_from_file = _get_contract_arguments(args)
     contract_address = Address.new_from_bech32(args.contract)
 
     proxy = ProxyNetworkProvider(args.proxy)
     function = args.function
-    arguments: List[Any] = args.arguments or []
 
-    result = query_contract(contract_address, proxy, function, arguments)
+    result = contract.query_contract(
+        contract_address=contract_address,
+        proxy=proxy,
+        function=function,
+        arguments=arguments,
+        args_from_file=args_from_file
+    )
+
     utils.dump_out_json(result)
 
 

--- a/multiversx_sdk_cli/cli_dns.py
+++ b/multiversx_sdk_cli/cli_dns.py
@@ -9,6 +9,7 @@ from multiversx_sdk_cli.dns import (compute_dns_address_for_shard_id,
                                     dns_address_for_name, name_hash, register,
                                     registration_cost, resolve, validate_name,
                                     version)
+from multiversx_sdk_cli.errors import ArgumentsNotProvidedError
 
 
 def setup_parser(args: List[str], subparsers: Any) -> Any:
@@ -32,7 +33,7 @@ def setup_parser(args: List[str], subparsers: Any) -> Any:
 
     sub = cli_shared.add_command_subparser(subparsers, "dns", "validate-name", "Asks one of the DNS contracts to validate a name. Can be useful before registering it.")
     _add_name_arg(sub)
-    sub.add_argument("--shard-id", default=0, help="shard id of the contract to call (default: %(default)s)")
+    sub.add_argument("--shard-id", type=int, default=0, help="shard id of the contract to call (default: %(default)s)")
     cli_shared.add_proxy_arg(sub)
     sub.set_defaults(func=dns_validate_name)
 
@@ -41,12 +42,12 @@ def setup_parser(args: List[str], subparsers: Any) -> Any:
     sub.set_defaults(func=get_name_hash)
 
     sub = cli_shared.add_command_subparser(subparsers, "dns", "registration-cost", "Gets the registration cost from a DNS smart contract, by default the one with shard id 0.")
-    sub.add_argument("--shard-id", default=0, help="shard id of the contract to call (default: %(default)s)")
+    sub.add_argument("--shard-id", type=int, default=0, help="shard id of the contract to call (default: %(default)s)")
     cli_shared.add_proxy_arg(sub)
     sub.set_defaults(func=get_registration_cost)
 
     sub = cli_shared.add_command_subparser(subparsers, "dns", "version", "Asks the contract for its version")
-    sub.add_argument("--shard-id", default=0, help="shard id of the contract to call (default: %(default)s)")
+    sub.add_argument("--shard-id", type=int, default=0, help="shard id of the contract to call (default: %(default)s)")
     sub.add_argument("--all", action="store_true", default=False, help="prints a list of all DNS contracts and their current versions (default: %(default)s)")
     cli_shared.add_proxy_arg(sub)
     sub.set_defaults(func=get_version)
@@ -70,13 +71,21 @@ def _add_name_arg(sub: Any):
     sub.add_argument("name", help="the name for which to check")
 
 
+def _ensure_proxy_is_provided(args: Any):
+    if not args.proxy:
+        raise ArgumentsNotProvidedError("'--proxy' argument not provided")
+
+
 def dns_resolve(args: Any):
+    _ensure_proxy_is_provided(args)
+
     addr = resolve(args.name, ProxyNetworkProvider(args.proxy))
     if addr.to_hex() != Address.new_from_bech32(ADDRESS_ZERO_BECH32).to_hex():
         print(addr.to_bech32())
 
 
 def dns_validate_name(args: Any):
+    _ensure_proxy_is_provided(args)
     validate_name(args.name, args.shard_id, ProxyNetworkProvider(args.proxy))
 
 
@@ -97,10 +106,13 @@ def get_dns_address_for_name_hex(args: Any):
 
 
 def get_registration_cost(args: Any):
+    _ensure_proxy_is_provided(args)
     print(registration_cost(args.shard_id, ProxyNetworkProvider(args.proxy)))
 
 
 def get_version(args: Any):
+    _ensure_proxy_is_provided(args)
+
     proxy = ProxyNetworkProvider(args.proxy)
     if args.all:
         t = PrettyTable(['Shard ID', 'Contract address (bech32)', 'Contract address (hex)', 'Version'])

--- a/multiversx_sdk_cli/cli_wallet.py
+++ b/multiversx_sdk_cli/cli_wallet.py
@@ -3,7 +3,7 @@ import json
 import logging
 import sys
 from pathlib import Path
-from typing import Any, List, Optional, Tuple
+from typing import Any, List, Optional, Tuple, cast
 
 from multiversx_sdk import (Address, Mnemonic, UserPEM, UserSecretKey,
                             UserWallet)
@@ -133,6 +133,9 @@ def wallet_new(args: Any):
             raise WalletGenerationError(f"Couldn't generate wallet in shard {shard}")
     else:
         mnemonic = Mnemonic.generate()
+
+    # this is done to get rid of the Pylance error: possibly unbound
+    mnemonic = cast(Mnemonic, mnemonic)  # type: ignore
 
     print(f"Mnemonic: {mnemonic.get_text()}")
     print(f"Wallet address: {mnemonic.derive_key().generate_public_key().to_address(address_hrp).to_bech32()}")

--- a/multiversx_sdk_cli/contract_verification.py
+++ b/multiversx_sdk_cli/contract_verification.py
@@ -112,7 +112,7 @@ def _create_request_signature(account: Account, contract_address: Address, reque
 
 
 def query_status_with_task_id(url: str, task_id: str, interval: int = 10):
-    logger.info(f"Please wait while we verify your contract. This may take a while.")
+    logger.info("Please wait while we verify your contract. This may take a while.")
     old_status = ""
 
     while True:
@@ -120,7 +120,7 @@ def query_status_with_task_id(url: str, task_id: str, interval: int = 10):
         status = response.get("status", "")
 
         if status == "finished":
-            logger.info(f"Verification finished!")
+            logger.info("Verification finished!")
             dump_out_json(response)
             break
         elif status != old_status:

--- a/multiversx_sdk_cli/contracts.py
+++ b/multiversx_sdk_cli/contracts.py
@@ -101,7 +101,7 @@ class SmartContract:
                                    guardian: str) -> Transaction:
         args = arguments if arguments else []
         if should_prepare_args:
-            args = self.prepare_args_for_factory(args)
+            args = self._prepare_args_for_factory(args)
 
         tx = self._factory.create_transaction_for_deploy(
             sender=owner.address,
@@ -139,7 +139,7 @@ class SmartContract:
 
         args = arguments if arguments else []
         if should_prepare_args:
-            args = self.prepare_args_for_factory(args)
+            args = self._prepare_args_for_factory(args)
 
         tx = self._factory.create_transaction_for_execute(
             sender=caller.address,
@@ -176,7 +176,7 @@ class SmartContract:
                                     guardian: str) -> Transaction:
         args = arguments if arguments else []
         if should_prepare_args:
-            args = self.prepare_args_for_factory(args)
+            args = self._prepare_args_for_factory(args)
 
         tx = self._factory.create_transaction_for_upgrade(
             sender=owner.address,

--- a/multiversx_sdk_cli/contracts.py
+++ b/multiversx_sdk_cli/contracts.py
@@ -203,9 +203,9 @@ class SmartContract:
                        proxy: INetworkProvider,
                        function: str,
                        arguments: List[Any],
-                       args_from_file: bool,) -> List[Any]:
+                       should_prepare_args: bool) -> List[Any]:
         args = arguments if arguments else []
-        if not args_from_file:
+        if should_prepare_args:
             args = self._prepare_args_for_factory(args)
 
         query_runner = QueryRunnerAdapter(proxy)

--- a/multiversx_sdk_cli/contracts.py
+++ b/multiversx_sdk_cli/contracts.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import Any, List, Optional, Protocol, Sequence, Union
+from typing import Any, List, Optional, Protocol, Union
 
 from multiversx_sdk import (Address, QueryRunnerAdapter,
                             SmartContractQueriesController,
@@ -8,13 +8,11 @@ from multiversx_sdk import (Address, QueryRunnerAdapter,
                             TokenComputer, TokenTransfer, Transaction,
                             TransactionPayload)
 from multiversx_sdk.abi import Abi
-from multiversx_sdk.network_providers.interface import IContractQuery
 
 from multiversx_sdk_cli import errors
 from multiversx_sdk_cli.accounts import Account
 from multiversx_sdk_cli.constants import DEFAULT_HRP
 from multiversx_sdk_cli.interfaces import IAddress
-from multiversx_sdk_cli.utils import Object
 
 logger = logging.getLogger("contracts")
 
@@ -27,37 +25,6 @@ STR_PREFIX = "str:"
 class INetworkProvider(Protocol):
     def query_contract(self, query: Any) -> 'IContractQueryResponse':
         ...
-
-
-class QueryResult(Object):
-    def __init__(self, as_base64: str, as_hex: str, as_number: Optional[int]):
-        self.base64 = as_base64
-        self.hex = as_hex
-        self.number = as_number
-
-
-class ContractQuery(IContractQuery):
-    def __init__(self, address: IAddress, function: str, value: int, arguments: List[bytes], caller: Optional[IAddress] = None):
-        self.contract = address
-        self.function = function
-        self.caller = caller
-        self.value = value
-        self.encoded_arguments = [item.hex() for item in arguments]
-
-    def get_contract(self) -> IAddress:
-        return self.contract
-
-    def get_function(self) -> str:
-        return self.function
-
-    def get_encoded_arguments(self) -> Sequence[str]:
-        return self.encoded_arguments
-
-    def get_caller(self) -> Optional[IAddress]:
-        return self.caller
-
-    def get_value(self) -> int:
-        return self.value
 
 
 class IContractQueryResponse(Protocol):
@@ -201,7 +168,7 @@ class SmartContract:
                        contract_address: IAddress,
                        proxy: INetworkProvider,
                        function: str,
-                       arguments: Union[List[Any], None],
+                       arguments: Optional[List[Any]],
                        should_prepare_args: bool) -> List[Any]:
         args = arguments if arguments else []
         if should_prepare_args:

--- a/multiversx_sdk_cli/contracts.py
+++ b/multiversx_sdk_cli/contracts.py
@@ -1,9 +1,11 @@
-import base64
 import logging
 from pathlib import Path
-from typing import Any, List, Optional, Protocol, Sequence, Union
+from typing import Any, Dict, List, Optional, Protocol, Sequence, Union
 
-from multiversx_sdk import (Address, SmartContractTransactionsFactory, Token,
+from multiversx_sdk import (Address, QueryRunnerAdapter,
+                            SmartContractQueriesController,
+                            SmartContractQueryResponse,
+                            SmartContractTransactionsFactory, Token,
                             TokenComputer, TokenTransfer, Transaction,
                             TransactionPayload)
 from multiversx_sdk.abi import Abi
@@ -63,6 +65,10 @@ class IContractQueryResponse(Protocol):
     return_data: List[str]
     return_code: str
     return_message: str
+    gas_used: int
+
+    def get_return_data_parts(self) -> List[bytes]:
+        ...
 
 
 class IConfig(Protocol):
@@ -95,7 +101,7 @@ class SmartContract:
                                    guardian: str) -> Transaction:
         args = arguments if arguments else []
         if not args_from_file:
-            args = self.prepare_args_for_factory(args)
+            args = self._prepare_args_for_factory(args)
 
         tx = self._factory.create_transaction_for_deploy(
             sender=owner.address,
@@ -133,7 +139,7 @@ class SmartContract:
 
         args = arguments if arguments else []
         if not args_from_file:
-            args = self.prepare_args_for_factory(args)
+            args = self._prepare_args_for_factory(args)
 
         tx = self._factory.create_transaction_for_execute(
             sender=caller.address,
@@ -168,11 +174,9 @@ class SmartContract:
                                     version: int,
                                     options: int,
                                     guardian: str) -> Transaction:
-        args = self.prepare_args_for_factory(arguments) if arguments else []
-
         args = arguments if arguments else []
         if not args_from_file:
-            args = self.prepare_args_for_factory(args)
+            args = self._prepare_args_for_factory(args)
 
         tx = self._factory.create_transaction_for_upgrade(
             sender=owner.address,
@@ -194,6 +198,40 @@ class SmartContract:
 
         return tx
 
+    def query_contract(self,
+                       contract_address: IAddress,
+                       proxy: INetworkProvider,
+                       function: str,
+                       arguments: List[Any],
+                       args_from_file: bool,) -> List[Any]:
+        args = arguments if arguments else []
+        if not args_from_file:
+            args = self._prepare_args_for_factory(args)
+
+        query_runner = QueryRunnerAdapter(proxy)
+        sc_query_controller = SmartContractQueriesController(query_runner, self._abi)
+
+        query = sc_query_controller.create_query(
+            contract=contract_address.to_bech32(),
+            function=function,
+            arguments=args
+        )
+
+        response = sc_query_controller.run_query(query)
+
+        if self._abi:
+            return sc_query_controller.parse_query_response(response)
+        else:
+            return [self._query_response_to_dict(response)]
+
+    def _query_response_to_dict(self, response: SmartContractQueryResponse) -> Dict[str, Any]:
+        return {
+            "function": response.function,
+            "returnCode": response.return_code,
+            "returnMessage": response.return_message,
+            "returnDataParts": [part.hex() for part in response.return_data_parts]
+        }
+
     def _prepare_token_transfers(self, transfers: List[str]) -> List[TokenTransfer]:
         token_computer = TokenComputer()
         token_transfers: List[TokenTransfer] = []
@@ -209,12 +247,12 @@ class SmartContract:
 
         return token_transfers
 
-    def prepare_args_for_factory(self, arguments: List[str]) -> List[Any]:
+    def _prepare_args_for_factory(self, arguments: List[str]) -> List[Any]:
         args: List[Any] = []
 
         for arg in arguments:
             if arg.startswith(HEX_PREFIX):
-                args.append(hex_to_bytes(arg))
+                args.append(self._hex_to_bytes(arg))
             elif arg.isnumeric():
                 args.append(int(arg))
             elif arg.startswith(DEFAULT_HRP):
@@ -230,64 +268,11 @@ class SmartContract:
 
         return args
 
-
-def query_contract(
-    contract_address: IAddress,
-    proxy: INetworkProvider,
-    function: str,
-    arguments: List[Any],
-    value: int = 0,
-    caller: Optional[IAddress] = None
-) -> List[Any]:
-    response_data = query_detailed(contract_address, proxy, function, arguments, value, caller)
-    return_data = response_data.return_data
-    return [_interpret_return_data(data) for data in return_data]
-
-
-def query_detailed(contract_address: IAddress, proxy: INetworkProvider, function: str, arguments: List[Any],
-                   value: int = 0, caller: Optional[IAddress] = None) -> Any:
-    arguments = arguments or []
-    # Temporary workaround, until we use sdk-core's serializer.
-    arguments_hex = [_prepare_argument(arg) for arg in arguments]
-    prepared_arguments_bytes = [bytes.fromhex(arg) for arg in arguments_hex]
-
-    query = ContractQuery(contract_address, function, value, prepared_arguments_bytes, caller)
-
-    response = proxy.query_contract(query)
-    # Temporary workaround, until we add "isSuccess" on the response class.
-    if response.return_code != "ok":
-        raise RuntimeError(f"Query failed: {response.return_message}")
-    return response
-
-
-def _interpret_return_data(data: str) -> Any:
-    if not data:
-        return data
-
-    try:
-        as_bytes = base64.b64decode(data)
-        as_hex = as_bytes.hex()
-        as_number = _interpret_as_number_if_safely(as_hex)
-
-        result = QueryResult(data, as_hex, as_number)
-        return result
-    except Exception:
-        logger.warn(f"Cannot interpret return data: {data}")
-        return None
-
-
-def _interpret_as_number_if_safely(as_hex: str) -> Optional[int]:
-    """
-    Makes sure the string can be safely converted to an int (and then back to a string).
-
-    See:
-        - https://stackoverflow.com/questions/73693104/valueerror-exceeds-the-limit-4300-for-integer-string-conversion 
-        - https://github.com/python/cpython/issues/95778
-    """
-    try:
-        return int(str(int(as_hex or "0", 16)))
-    except:
-        return None
+    def _hex_to_bytes(self, arg: str):
+        argument = arg[len(HEX_PREFIX):]
+        argument = argument.upper()
+        argument = ensure_even_length(argument)
+        return bytes.fromhex(argument)
 
 
 def prepare_execute_transaction_data(function: str, arguments: List[Any]) -> TransactionPayload:
@@ -299,14 +284,7 @@ def prepare_execute_transaction_data(function: str, arguments: List[Any]) -> Tra
     return TransactionPayload.from_str(tx_data)
 
 
-def hex_to_bytes(arg: str):
-    argument = arg[len(HEX_PREFIX):]
-    argument = argument.upper()
-    argument = ensure_even_length(argument)
-    return bytes.fromhex(argument)
-
-
-# only used for contract queries and stake operations
+# only used for stake operations
 def _prepare_argument(argument: Any):
     as_str = str(argument)
     as_hex = _to_hex(as_str)

--- a/multiversx_sdk_cli/dns.py
+++ b/multiversx_sdk_cli/dns.py
@@ -100,7 +100,7 @@ def registration_cost(shard_id: int, proxy: INetworkProvider) -> int:
     response = _query_contract(
         contract_address=dns_address,
         proxy=proxy,
-        function="versgetRegistrationCostion",
+        function="getRegistrationCost",
         args=[]
     )
 

--- a/multiversx_sdk_cli/errors.py
+++ b/multiversx_sdk_cli/errors.py
@@ -1,5 +1,3 @@
-
-from pathlib import Path
 from typing import Any, List, Tuple, Union
 
 
@@ -20,16 +18,6 @@ class KnownError(Exception):
 
 class ProgrammingError(KnownError):
     pass
-
-
-class TemplateMissingError(KnownError):
-    def __init__(self, template: str):
-        super().__init__(f"Template missing: {template}")
-
-
-class BadTemplateError(KnownError):
-    def __init__(self, directory: Path):
-        super().__init__(f"Bad template: {directory}")
 
 
 class DownloadError(KnownError):
@@ -75,7 +63,7 @@ class BadDirectory(KnownError):
 
 
 class BadFile(KnownError):
-    def __init__(self, filename: str, inner=None):
+    def __init__(self, filename: str, inner: Any = None):
         super().__init__(f"Bad file: {filename}.", inner)
 
 
@@ -104,16 +92,6 @@ class BadInputError(KnownError):
         super().__init__(f"Bad input [{input}]: {message}")
 
 
-class BadAddressFormatError(KnownError):
-    def __init__(self, value: str):
-        super().__init__(f"Bad address [{value}].")
-
-
-class EmptyAddressError(KnownError):
-    def __init__(self):
-        super().__init__("Address is empty.")
-
-
 class ExternalProcessError(KnownError):
     def __init__(self, command_line: str, message: str):
         super().__init__(f"""External process error:
@@ -134,25 +112,6 @@ class ConfigurationShouldBeUniqueError(KnownError):
 class ConfigurationProtectedError(KnownError):
     def __init__(self, name: str):
         super().__init__(f"This configuration name is protected: {name}.")
-
-
-class UnsupportedConfigurationValue(KnownError):
-    pass
-
-
-class UnknownDerivationFunction(KnownError):
-    def __init__(self):
-        super().__init__("Unknown key derivation function.")
-
-
-class UnknownCipher(KnownError):
-    def __init__(self, name: str):
-        super().__init__(f"Unknown cipher: {name}.")
-
-
-class GasLimitTooLarge(KnownError):
-    def __init__(self, current: int, limit: int):
-        super().__init__(f"The gas limit provided ({current}) exceeds the max gas limit of allowed for a transaction ({limit})")
 
 
 class BadUserInput(KnownError):
@@ -213,3 +172,8 @@ class ProxyError(KnownError):
 class WalletGenerationError(KnownError):
     def __init__(self, message: str):
         super().__init__(message)
+
+
+class QueryContractError(KnownError):
+    def __init__(self, message: str, inner: Any = None):
+        super().__init__(message, str(inner))

--- a/multiversx_sdk_cli/tests/test_cli_contracts.py
+++ b/multiversx_sdk_cli/tests/test_cli_contracts.py
@@ -213,7 +213,7 @@ def test_contract_flow(capsys: Any):
         "--pem", alice,
         "--recall-nonce",
         "--gas-limit", "5000000",
-        "--proxy", "https://testnet-api.multiversx.com",
+        "--proxy", "https://testnet-gateway.multiversx.com",
         "--arguments", "0",
         "--send", "--wait-result"
     ])
@@ -225,7 +225,7 @@ def test_contract_flow(capsys: Any):
     main([
         "contract", "query", contract,
         "--function", "getSum",
-        "--proxy", "https://testnet-api.multiversx.com"
+        "--proxy", "https://testnet-gateway.multiversx.com"
     ])
     response = get_query_response(capsys)
     assert len(response) == 1
@@ -240,7 +240,7 @@ def test_contract_flow(capsys: Any):
         "--function", "add",
         "--recall-nonce",
         "--gas-limit", "5000000",
-        "--proxy", "https://testnet-api.multiversx.com",
+        "--proxy", "https://testnet-gateway.multiversx.com",
         "--arguments", "7",
         "--send", "--wait-result"
     ])
@@ -251,7 +251,7 @@ def test_contract_flow(capsys: Any):
     main([
         "contract", "query", contract,
         "--function", "getSum",
-        "--proxy", "https://testnet-api.multiversx.com"
+        "--proxy", "https://testnet-gateway.multiversx.com"
     ])
     response = get_query_response(capsys)
     assert len(response) == 1
@@ -266,7 +266,7 @@ def test_contract_flow(capsys: Any):
         "--pem", alice,
         "--recall-nonce",
         "--gas-limit", "5000000",
-        "--proxy", "https://testnet-api.multiversx.com",
+        "--proxy", "https://testnet-gateway.multiversx.com",
         "--arguments", "0",
         "--send", "--wait-result"
     ])

--- a/multiversx_sdk_cli/tests/test_cli_contracts.py
+++ b/multiversx_sdk_cli/tests/test_cli_contracts.py
@@ -213,7 +213,7 @@ def test_contract_flow(capsys: Any):
         "--pem", alice,
         "--recall-nonce",
         "--gas-limit", "5000000",
-        "--proxy", "https://testnet-gateway.multiversx.com",
+        "--proxy", "https://testnet-api.multiversx.com",
         "--arguments", "0",
         "--send", "--wait-result"
     ])
@@ -225,7 +225,7 @@ def test_contract_flow(capsys: Any):
     main([
         "contract", "query", contract,
         "--function", "getSum",
-        "--proxy", "https://testnet-gateway.multiversx.com"
+        "--proxy", "https://testnet-api.multiversx.com"
     ])
     response = get_query_response(capsys)
     assert len(response) == 1
@@ -240,7 +240,7 @@ def test_contract_flow(capsys: Any):
         "--function", "add",
         "--recall-nonce",
         "--gas-limit", "5000000",
-        "--proxy", "https://testnet-gateway.multiversx.com",
+        "--proxy", "https://testnet-api.multiversx.com",
         "--arguments", "7",
         "--send", "--wait-result"
     ])
@@ -251,7 +251,7 @@ def test_contract_flow(capsys: Any):
     main([
         "contract", "query", contract,
         "--function", "getSum",
-        "--proxy", "https://testnet-gateway.multiversx.com"
+        "--proxy", "https://testnet-api.multiversx.com"
     ])
     response = get_query_response(capsys)
     assert len(response) == 1
@@ -266,7 +266,7 @@ def test_contract_flow(capsys: Any):
         "--pem", alice,
         "--recall-nonce",
         "--gas-limit", "5000000",
-        "--proxy", "https://testnet-gateway.multiversx.com",
+        "--proxy", "https://testnet-api.multiversx.com",
         "--arguments", "0",
         "--send", "--wait-result"
     ])

--- a/multiversx_sdk_cli/tests/test_cli_contracts.py
+++ b/multiversx_sdk_cli/tests/test_cli_contracts.py
@@ -229,7 +229,9 @@ def test_contract_flow(capsys: Any):
         "--proxy", "https://testnet-api.multiversx.com"
     ])
     response = get_query_response(capsys)
-    assert response == ""
+    return_data_parts = response["returnDataParts"]
+    assert len(return_data_parts) == 1
+    assert return_data_parts == [""]
 
     # Clear the captured content
     capsys.readouterr()
@@ -256,7 +258,9 @@ def test_contract_flow(capsys: Any):
         "--proxy", "https://testnet-api.multiversx.com"
     ])
     response = get_query_response(capsys)
-    assert response["number"] == 7
+    return_data_parts = response["returnDataParts"]
+    assert len(return_data_parts) == 1
+    assert return_data_parts == ["07"]
 
     # Clear the captured content
     capsys.readouterr()

--- a/multiversx_sdk_cli/tests/test_contracts.py
+++ b/multiversx_sdk_cli/tests/test_contracts.py
@@ -8,9 +8,7 @@ from multiversx_sdk import Address, TransactionsFactoryConfig
 from multiversx_sdk_cli import errors
 from multiversx_sdk_cli.accounts import Account
 from multiversx_sdk_cli.contract_verification import _create_request_signature
-from multiversx_sdk_cli.contracts import (SmartContract,
-                                          _interpret_as_number_if_safely,
-                                          _prepare_argument)
+from multiversx_sdk_cli.contracts import SmartContract, _prepare_argument
 
 logging.basicConfig(level=logging.INFO)
 
@@ -63,12 +61,6 @@ def test_contract_verification_create_request_signature():
     assert signature.hex() == "30111258cc42ea08e0c6a3e053cc7086a88d614b8b119a244904e9a19896c73295b2fe5c520a1cb07cfe20f687deef9f294a0a05071e85c78a70a448ea5f0605"
 
 
-def test_interpret_as_number_if_safely():
-    assert _interpret_as_number_if_safely("") == 0
-    assert _interpret_as_number_if_safely("0x5") == 5
-    assert _interpret_as_number_if_safely("FF") == 255
-
-
 def test_prepare_args_for_factories():
     sc = SmartContract(TransactionsFactoryConfig("mock"))
     args = [
@@ -77,10 +69,10 @@ def test_prepare_args_for_factories():
         "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th"
     ]
 
-    arguments = sc.prepare_args_for_factory(args)
+    arguments = sc._prepare_args_for_factory(args)
     assert arguments[0] == b"\x05"
     assert arguments[1] == 123
-    assert arguments[2] == False
-    assert arguments[3] == True
+    assert arguments[2] is False
+    assert arguments[3] is True
     assert arguments[4] == "test-string"
     assert arguments[5].to_bech32() == "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th"

--- a/multiversx_sdk_cli/tests/test_shared.py
+++ b/multiversx_sdk_cli/tests/test_shared.py
@@ -19,7 +19,7 @@ def test_prepare_chain_id_in_args():
         prepare_chain_id_in_args(args)
 
     args.chain = "I"
-    args.proxy = "https://testnet-gateway.multiversx.com"
+    args.proxy = "https://testnet-api.multiversx.com"
 
     prepare_chain_id_in_args(args)
     assert args.chain == "T"

--- a/multiversx_sdk_cli/tests/testdata/adder.abi.json
+++ b/multiversx_sdk_cli/tests/testdata/adder.abi.json
@@ -1,0 +1,72 @@
+{
+    "buildInfo": {
+        "rustc": {
+            "version": "1.79.0",
+            "commitHash": "129f3b9964af4d4a709d1383930ade12dfe7c081",
+            "commitDate": "2024-06-10",
+            "channel": "Stable",
+            "short": "rustc 1.79.0 (129f3b996 2024-06-10)"
+        },
+        "contractCrate": {
+            "name": "adder",
+            "version": "0.0.0",
+            "gitVersion": "v0.45.2.1-reproducible-337-g5478c6e"
+        },
+        "framework": {
+            "name": "multiversx-sc",
+            "version": "0.51.1"
+        }
+    },
+    "docs": [
+        "One of the simplest smart contracts possible,",
+        "it holds a single variable in storage, which anyone can increment."
+    ],
+    "name": "Adder",
+    "constructor": {
+        "inputs": [
+            {
+                "name": "initial_value",
+                "type": "BigUint"
+            }
+        ],
+        "outputs": []
+    },
+    "upgradeConstructor": {
+        "inputs": [
+            {
+                "name": "initial_value",
+                "type": "BigUint"
+            }
+        ],
+        "outputs": []
+    },
+    "endpoints": [
+        {
+            "name": "getSum",
+            "mutability": "readonly",
+            "inputs": [],
+            "outputs": [
+                {
+                    "type": "BigUint"
+                }
+            ]
+        },
+        {
+            "docs": [
+                "Add desired amount to the storage variable."
+            ],
+            "name": "add",
+            "mutability": "mutable",
+            "inputs": [
+                {
+                    "name": "value",
+                    "type": "BigUint"
+                }
+            ],
+            "outputs": []
+        }
+    ],
+    "esdtAttributes": [],
+    "hasCallback": false,
+    "types": {}
+}

--- a/multiversx_sdk_cli/transactions.py
+++ b/multiversx_sdk_cli/transactions.py
@@ -212,7 +212,7 @@ def tx_to_dictionary_as_inner_for_relayed_V1(tx: Transaction) -> Dict[str, Any]:
         dictionary["sndUserName"] = base64.b64encode(tx.sender_username.encode()).decode()
 
     if tx.receiver_username:
-        dictionary[f"rcvUserName"] = base64.b64encode(tx.receiver_username.encode()).decode()
+        dictionary["rcvUserName"] = base64.b64encode(tx.receiver_username.encode()).decode()
 
     return dictionary
 

--- a/multiversx_sdk_cli/utils.py
+++ b/multiversx_sdk_cli/utils.py
@@ -42,8 +42,6 @@ class BasicEncoder(json.JSONEncoder):
             return o.to_dictionary()
         if isinstance(o, bytes):
             return o.hex()
-        if isinstance(o, list):
-            return [self.default(item) for item in o]  # type: ignore
         return super().default(o)
 
 

--- a/multiversx_sdk_cli/utils.py
+++ b/multiversx_sdk_cli/utils.py
@@ -37,9 +37,13 @@ class Object(ISerializable):
 
 
 class BasicEncoder(json.JSONEncoder):
-    def default(self, o: Any):
+    def default(self, o: Any) -> Any:
         if isinstance(o, ISerializable):
             return o.to_dictionary()
+        if isinstance(o, bytes):
+            return o.hex()
+        if isinstance(o, list):
+            return [self.default(item) for item in o]  # type: ignore
         return super().default(o)
 
 


### PR DESCRIPTION
The same arguments as for contract calls have been added. The args are `--abi` and `--arguments-file`. Keep in mind the args should be placed inside a `list` like such:
```json
[
    5,
    {
         { "bech32": "erd1..." }
    }
]
```

When performing queries without the abi file the response looks like this:
```sh
[
    "0e"
]
```

But when using the abi file the response is parsed, and it looks like this:
```sh
[
    14
]
```

There are small differences in how values are returned. For example, if an endpoint returns `variadic<Address>`, when querying without abi, the response looks like this:
```
[
    "3c35d7eacb1a99a4a0ccaa537ef0cc0ae109f41f6c2b402203e633bfbb071f5c",
    "0139472eff6886771a982f3083da5d421f24c29181e63888228dc81ca60d69e1"
]
```

But when the abi is used, the response looks like this:
```
[
    [
        "3c35d7eacb1a99a4a0ccaa537ef0cc0ae109f41f6c2b402203e633bfbb071f5c",
        "0139472eff6886771a982f3083da5d421f24c29181e63888228dc81ca60d69e1"
    ]
]
```