### PR TITLE
Generate wallet in specific shard

### DIFF
--- a/multiversx_sdk_cli/cli_wallet.py
+++ b/multiversx_sdk_cli/cli_wallet.py
@@ -34,7 +34,7 @@ WALLET_FORMATS = [
 WALLET_FORMATS_AND_ADDRESSES = [*WALLET_FORMATS, WALLET_FORMAT_ADDRESS_BECH32, WALLET_FORMAT_ADDRESS_HEX]
 
 MAX_ITERATIONS_FOR_GENERATING_WALLET = 100
-CURRENT_SHARDS = [0, 1, 2]
+CURRENT_SHARDS = [i for i in range(NUMBER_OF_SHARDS)]
 
 
 def setup_parser(args: List[str], subparsers: Any) -> Any:
@@ -115,8 +115,7 @@ def wallet_new(args: Any):
     shard = args.shard
 
     if shard in CURRENT_SHARDS:
-        i = 0
-        while i < MAX_ITERATIONS_FOR_GENERATING_WALLET:
+        for i in range(MAX_ITERATIONS_FOR_GENERATING_WALLET):
             mnemonic = Mnemonic.generate()
             pubkey = mnemonic.derive_key().generate_public_key()
             generated_address_shard = get_shard_of_pubkey(pubkey.buffer, NUMBER_OF_SHARDS)
@@ -124,8 +123,7 @@ def wallet_new(args: Any):
             if shard == generated_address_shard:
                 break
 
-            i += 1
-            if i == 100:
+            if i == 99:
                 raise Exception(f"Couldn't generate wallet in shard {shard}")
     else:
         mnemonic = Mnemonic.generate()

--- a/multiversx_sdk_cli/cli_wallet.py
+++ b/multiversx_sdk_cli/cli_wallet.py
@@ -7,9 +7,10 @@ from typing import Any, List, Optional, Tuple
 
 from multiversx_sdk import (Address, Mnemonic, UserPEM, UserSecretKey,
                             UserWallet)
+from multiversx_sdk.core.address import get_shard_of_pubkey
 
 from multiversx_sdk_cli import cli_shared, utils
-from multiversx_sdk_cli.constants import DEFAULT_HRP
+from multiversx_sdk_cli.constants import DEFAULT_HRP, NUMBER_OF_SHARDS
 from multiversx_sdk_cli.errors import KnownError
 from multiversx_sdk_cli.sign_verify import SignedMessage, sign_message
 from multiversx_sdk_cli.ux import show_critical_error, show_message
@@ -32,6 +33,9 @@ WALLET_FORMATS = [
 
 WALLET_FORMATS_AND_ADDRESSES = [*WALLET_FORMATS, WALLET_FORMAT_ADDRESS_BECH32, WALLET_FORMAT_ADDRESS_HEX]
 
+MAX_ITERATIONS_FOR_GENERATING_WALLET = 100
+CURRENT_SHARDS = [0, 1, 2]
+
 
 def setup_parser(args: List[str], subparsers: Any) -> Any:
     parser = cli_shared.add_group_subparser(
@@ -50,6 +54,7 @@ def setup_parser(args: List[str], subparsers: Any) -> Any:
     sub.add_argument("--format", choices=WALLET_FORMATS, help="the format of the generated wallet file (default: %(default)s)", default=None)
     sub.add_argument("--outfile", help="the output path and base file name for the generated wallet files (default: %(default)s)", type=str)
     sub.add_argument("--address-hrp", help=f"the human-readable part of the address, when format is {WALLET_FORMAT_KEYSTORE_SECRET_KEY} or {WALLET_FORMAT_PEM} (default: %(default)s)", type=str, default=DEFAULT_HRP)
+    sub.add_argument("--shard", type=int, help="the shard in which the address will be generated; (default: random)")
     sub.set_defaults(func=wallet_new)
 
     sub = cli_shared.add_command_subparser(
@@ -107,8 +112,21 @@ def wallet_new(args: Any):
     format = args.format
     outfile = args.outfile
     address_hrp = args.address_hrp
+    shard = args.shard
 
-    mnemonic = Mnemonic.generate()
+    if shard in CURRENT_SHARDS:
+        i = 0
+        while i < MAX_ITERATIONS_FOR_GENERATING_WALLET:
+            mnemonic = Mnemonic.generate()
+            pubkey = mnemonic.derive_key().generate_public_key()
+            generated_address_shard = get_shard_of_pubkey(pubkey.buffer, NUMBER_OF_SHARDS)
+
+            if shard == generated_address_shard:
+                break
+        raise Exception(f"Couldn't generate wallet in shard {shard}")
+    else:
+        mnemonic = Mnemonic.generate()
+
     print(f"Mnemonic: {mnemonic.get_text()}")
     print(f"Wallet address: {mnemonic.derive_key().generate_public_key().to_address(address_hrp).to_bech32()}")
 
@@ -158,7 +176,7 @@ def convert_wallet(args: Any):
     if infile:
         input_text = infile.read_text()
     else:
-        print(f"Insert text below. Press 'Ctrl-D' (Linux / MacOS) or 'Ctrl-Z' (Windows) when done.")
+        print("Insert text below. Press 'Ctrl-D' (Linux / MacOS) or 'Ctrl-Z' (Windows) when done.")
         input_text = sys.stdin.read().strip()
 
     mnemonic, secret_key = _load_wallet(input_text, in_format, address_index)

--- a/multiversx_sdk_cli/cli_wallet.py
+++ b/multiversx_sdk_cli/cli_wallet.py
@@ -123,7 +123,10 @@ def wallet_new(args: Any):
 
             if shard == generated_address_shard:
                 break
-        raise Exception(f"Couldn't generate wallet in shard {shard}")
+
+            i += 1
+            if i == 100:
+                raise Exception(f"Couldn't generate wallet in shard {shard}")
     else:
         mnemonic = Mnemonic.generate()
 

--- a/multiversx_sdk_cli/cli_wallet.py
+++ b/multiversx_sdk_cli/cli_wallet.py
@@ -115,7 +115,7 @@ def wallet_new(args: Any):
     address_hrp = args.address_hrp
     shard = args.shard
 
-    if shard:
+    if shard is not None:
         if shard not in CURRENT_SHARDS:
             raise BadUserInput(f"Wrong shard provided. Choose between {CURRENT_SHARDS}")
 

--- a/multiversx_sdk_cli/errors.py
+++ b/multiversx_sdk_cli/errors.py
@@ -208,3 +208,8 @@ class ProxyError(KnownError):
             "code": code
         }
         super().__init__(message, inner)
+
+
+class WalletGenerationError(KnownError):
+    def __init__(self, message: str):
+        super().__init__(message)

--- a/multiversx_sdk_cli/tests/test_cli_wallet.py
+++ b/multiversx_sdk_cli/tests/test_cli_wallet.py
@@ -3,7 +3,8 @@ import json
 from pathlib import Path
 from typing import Any
 
-from multiversx_sdk import Mnemonic, UserPEM, UserWallet
+from multiversx_sdk import (Address, AddressComputer, Mnemonic, UserPEM,
+                            UserWallet)
 
 from multiversx_sdk_cli.cli import main
 
@@ -15,6 +16,22 @@ def test_wallet_new(capsys: Any):
     main(["wallet", "new"])
     displayed_mnemonic = _read_stdout_mnemonic(capsys)
     assert Mnemonic.is_text_valid(displayed_mnemonic)
+
+
+def test_generate_wallet_in_specific_shard(capsys: Any):
+    address_computer = AddressComputer()
+
+    main(["wallet", "new", "--shard", "0"])
+    address = Address.new_from_bech32(_read_stdout_wallet_address(capsys))
+    assert address_computer.get_shard_of_address(address) == 0
+
+    main(["wallet", "new", "--shard", "1"])
+    address = Address.new_from_bech32(_read_stdout_wallet_address(capsys))
+    assert address_computer.get_shard_of_address(address) == 1
+
+    main(["wallet", "new", "--shard", "2"])
+    address = Address.new_from_bech32(_read_stdout_wallet_address(capsys))
+    assert address_computer.get_shard_of_address(address) == 2
 
 
 def test_wallet_new_and_save_in_pem_format(capsys: Any):
@@ -369,6 +386,11 @@ def test_sign_and_verify_message_with_multi_address_pem(capsys: Any):
 def _read_stdout_mnemonic(capsys: Any) -> str:
     lines = _read_stdout(capsys).split("\n")
     return lines[0].replace("Mnemonic:", "").strip()
+
+
+def _read_stdout_wallet_address(capsys: Any) -> str:
+    lines = _read_stdout(capsys).split("\n")
+    return lines[1].replace("Wallet address:", "").strip()
 
 
 def _read_stdout(capsys: Any) -> str:


### PR DESCRIPTION
For the `mxpy wallet new` command a new **optional** argument `--shard` has been added. When this argument is provided a wallet will be generated in that specific shard.