### PR TITLE
Log level warning to info when config file exists

### DIFF
--- a/multiversx_sdk_cli/localnet/step_new.py
+++ b/multiversx_sdk_cli/localnet/step_new.py
@@ -12,7 +12,7 @@ def new_config(configfile: Path):
     configfile = configfile.expanduser().resolve()
 
     if configfile.exists():
-        logger.warning(f"Configuration file already exists: {configfile}")
+        logger.info(f"Configuration file already exists: {configfile}")
         return
 
     config = ConfigRoot()


### PR DESCRIPTION
Changed log level for localnet setup from warning to info when the configuration file already exists.