### PR TITLE
Adjust localnet config to work with Spica (upcoming release)

### DIFF
--- a/multiversx_sdk_cli/localnet/node_config_toml.py
+++ b/multiversx_sdk_cli/localnet/node_config_toml.py
@@ -26,14 +26,8 @@ def patch_config(data: ConfigDict, config: ConfigRoot):
     data['EpochStartConfig'].update(epoch_start_config)
 
     # Always use the latest VM
-    virtual_machine: Dict[str, Any] = dict()
-    virtual_machine['Execution'] = dict()
-    virtual_machine['Execution']['WasmVMVersions'] = [{'StartEpoch': 0, 'Version': '*'}]
-    virtual_machine['Querying'] = dict()
-    virtual_machine['Querying']['NumConcurrentVMs'] = 1
-    virtual_machine['Querying']['WasmVMVersions'] = [{'StartEpoch': 0, 'Version': '*'}]
-
-    data['VirtualMachine'].update(virtual_machine)
+    data['VirtualMachine']['Execution']['WasmVMVersions'] = [{'StartEpoch': 0, 'Version': '*'}]
+    data['VirtualMachine']['Querying']['WasmVMVersions'] = [{'StartEpoch': 0, 'Version': '*'}]
 
 
 def patch_api(data: ConfigDict, config: ConfigRoot):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "multiversx-sdk-cli"
-version = "9.6.0"
+version = "9.6.1"
 authors = [
   { name="MultiversX" },
 ]


### PR DESCRIPTION
Simplify logic that adjusts `config.toml`, section `[VirtualMachine]`.


See https://github.com/multiversx/mx-chain-testnet-config/blob/T1.7.17.0/config.toml#L669.