### PR TITLE
Update localnet (Spica, gateway): upwards & backwards compatibility

### DIFF
--- a/multiversx_sdk_cli/localnet/step_config.py
+++ b/multiversx_sdk_cli/localnet/step_config.py
@@ -171,17 +171,13 @@ def copy_config_to_proxy(config: ConfigRoot):
     proxy_config = config.proxy_config_folder()
     makefolder(proxy_config)
 
-    shutil.copy(
-        config_prototype / 'config.toml',
-        proxy_config)
+    shutil.copy(config_prototype / 'config.toml', proxy_config)
+    shutil.copytree(config_prototype / 'apiConfig', proxy_config / 'apiConfig')
 
-    shutil.copytree(
-        config_prototype / 'apiConfig',
-        proxy_config / 'apiConfig')
-
-    shutil.copy(
-        config_prototype / 'external.toml',
-        proxy_config)
+    # Removed in newer versions:
+    # https://github.com/multiversx/mx-chain-proxy-go/pull/454
+    if (config_prototype / 'external.toml').exists():
+        shutil.copy(config_prototype / 'external.toml', proxy_config)
 
 
 def patch_proxy_config(config: ConfigRoot):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "multiversx-sdk-cli"
-version = "9.7.0"
+version = "9.7.1"
 authors = [
   { name="MultiversX" },
 ]


### PR DESCRIPTION
Also see: https://github.com/multiversx/mx-chain-proxy-go/pull/454.