### PR TITLE
Remove relayed V3 related code and tests

### DIFF
--- a/multiversx_sdk_cli/cli_shared.py
+++ b/multiversx_sdk_cli/cli_shared.py
@@ -92,15 +92,8 @@ def add_tx_args(
     sub.add_argument("--version", type=int, default=DEFAULT_TX_VERSION, help="the transaction version (default: %(default)s)")
 
     add_guardian_args(sub)
-    add_relayed_v3_args(sub)
 
     sub.add_argument("--options", type=int, default=0, help="the transaction options (default: 0)")
-
-
-def add_relayed_v3_args(sub: Any):
-    sub.add_argument("--relayer", help="the address of the relayer")
-    sub.add_argument("--inner-transactions", help="a json file containing the inner transactions; should only be provided when creating the relayer's transaction")
-    sub.add_argument("--inner-transactions-outfile", type=str, help="where to save the transaction as an inner transaction (default: stdout)")
 
 
 def add_guardian_args(sub: Any):

--- a/multiversx_sdk_cli/cli_transactions.py
+++ b/multiversx_sdk_cli/cli_transactions.py
@@ -1,17 +1,14 @@
 import logging
 from pathlib import Path
-from typing import Any, Dict, List
-
-from multiversx_sdk import Transaction, TransactionsConverter
+from typing import Any, List
 
 from multiversx_sdk_cli import cli_shared, utils
 from multiversx_sdk_cli.cli_output import CLIOutputBuilder
 from multiversx_sdk_cli.cosign_transaction import cosign_transaction
 from multiversx_sdk_cli.custom_network_provider import CustomNetworkProvider
-from multiversx_sdk_cli.errors import BadUsage, NoWalletProvided
+from multiversx_sdk_cli.errors import NoWalletProvided
 from multiversx_sdk_cli.transactions import (compute_relayed_v1_data,
                                              do_prepare_transaction,
-                                             load_inner_transactions_from_file,
                                              load_transaction_from_file)
 
 logger = logging.getLogger("cli.transactions")
@@ -85,13 +82,7 @@ def create_transaction(args: Any):
     if args.data_file:
         args.data = Path(args.data_file).read_text()
 
-    check_relayer_transaction_with_data_field_for_relayed_v3(args)
-
     tx = do_prepare_transaction(args)
-
-    if hasattr(args, "inner_transactions_outfile") and args.inner_transactions_outfile:
-        save_transaction_to_inner_transactions_file(tx, args)
-        return
 
     if hasattr(args, "relay") and args.relay:
         logger.warning("RelayedV1 transactions are deprecated. Please use RelayedV3 instead.")
@@ -99,30 +90,6 @@ def create_transaction(args: Any):
         return
 
     cli_shared.send_or_simulate(tx, args)
-
-
-def save_transaction_to_inner_transactions_file(transaction: Transaction, args: Any):
-    inner_txs_file = Path(args.inner_transactions_outfile).expanduser()
-    transactions = get_inner_transactions_if_any(inner_txs_file)
-    transactions.append(transaction)
-
-    tx_converter = TransactionsConverter()
-    inner_transactions: Dict[str, Any] = {}
-    inner_transactions["innerTransactions"] = [tx_converter.transaction_to_dictionary(tx) for tx in transactions]
-
-    with open(inner_txs_file, "w") as file:
-        utils.dump_out_json(inner_transactions, file)
-
-
-def get_inner_transactions_if_any(file: Path) -> List[Transaction]:
-    if file.is_file():
-        return load_inner_transactions_from_file(file)
-    return []
-
-
-def check_relayer_transaction_with_data_field_for_relayed_v3(args: Any):
-    if hasattr(args, "inner_transactions") and args.inner_transactions and args.data:
-        raise BadUsage("Can't set data field when creating a relayedV3 transaction")
 
 
 def send_transaction(args: Any):

--- a/multiversx_sdk_cli/tests/test_cli_transactions.py
+++ b/multiversx_sdk_cli/tests/test_cli_transactions.py
@@ -1,7 +1,6 @@
 import json
-import os
 from pathlib import Path
-from typing import Any, List
+from typing import Any
 
 from multiversx_sdk_cli.cli import main
 
@@ -87,94 +86,6 @@ def test_create_multi_transfer_transaction(capsys: Any):
     tx_json = json.loads(tx)
     signature = tx_json["emittedTransaction"]["signature"]
     assert signature == "575b029d52ff5ffbfb7bab2f04052de88a6f7d022a6ad368459b8af9acaed3717d3f95db09f460649a8f405800838bc2c432496bd03c9039ea166bd32b84660e"
-
-
-def test_create_and_save_inner_transaction():
-    return_code = main([
-        "tx", "new",
-        "--pem", str(testdata_path / "alice.pem"),
-        "--receiver", "erd1spyavw0956vq68xj8y4tenjpq2wd5a9p2c6j8gsz7ztyrnpxrruqzu66jx",
-        "--nonce", "77",
-        "--gas-limit", "500000",
-        "--relayer", "erd1k2s324ww2g0yj38qn2ch2jwctdy8mnfxep94q9arncc6xecg3xaq6mjse8",
-        "--inner-transactions-outfile", str(testdata_out / "inner_transactions.json"),
-        "--chain", "T",
-    ])
-    assert False if return_code else True
-    assert Path(testdata_out / "inner_transactions.json").is_file()
-
-
-def test_create_and_append_inner_transaction():
-    return_code = main([
-        "tx", "new",
-        "--pem", str(testdata_path / "alice.pem"),
-        "--receiver", "erd1fggp5ru0jhcjrp5rjqyqrnvhr3sz3v2e0fm3ktknvlg7mcyan54qzccnan",
-        "--nonce", "1234",
-        "--gas-limit", "50000",
-        "--relayer", "erd1k2s324ww2g0yj38qn2ch2jwctdy8mnfxep94q9arncc6xecg3xaq6mjse8",
-        "--inner-transactions-outfile", str(testdata_out / "inner_transactions.json"),
-        "--chain", "T",
-    ])
-    assert False if return_code else True
-
-    with open(testdata_out / "inner_transactions.json", "r") as file:
-        json_file = json.load(file)
-
-    inner_txs: List[Any] = json_file["innerTransactions"]
-    assert len(inner_txs) == 2
-
-
-def test_create_invalid_relayed_transaction():
-    return_code = main([
-        "tx", "new",
-        "--pem", str(testdata_path / "testUser.pem"),
-        "--receiver", "erd1cqqxak4wun7508e0yj9ng843r6hv4mzd0hhpjpsejkpn9wa9yq8sj7u2u5",
-        "--nonce", "987",
-        "--gas-limit", "5000000",
-        "--inner-transactions", str(testdata_out / "inner_transactions.json"),
-        "--data", "test data",
-        "--chain", "T",
-    ])
-    assert return_code
-
-
-def test_create_relayer_transaction(capsys: Any):
-    return_code = main([
-        "tx", "new",
-        "--pem", str(testdata_path / "testUser.pem"),
-        "--receiver", "erd1cqqxak4wun7508e0yj9ng843r6hv4mzd0hhpjpsejkpn9wa9yq8sj7u2u5",
-        "--nonce", "987",
-        "--gas-limit", "5000000",
-        "--inner-transactions", str(testdata_out / "inner_transactions.json"),
-        "--chain", "T",
-    ])
-    # remove test file to ensure consistency when running test file locally
-    os.remove(testdata_out / "inner_transactions.json")
-
-    assert False if return_code else True
-
-    tx = _read_stdout(capsys)
-    tx_json = json.loads(tx)["emittedTransaction"]
-
-    assert tx_json["sender"] == "erd1cqqxak4wun7508e0yj9ng843r6hv4mzd0hhpjpsejkpn9wa9yq8sj7u2u5"
-    assert tx_json["receiver"] == "erd1cqqxak4wun7508e0yj9ng843r6hv4mzd0hhpjpsejkpn9wa9yq8sj7u2u5"
-    assert tx_json["gasLimit"] == 5000000
-    assert tx_json["nonce"] == 987
-    assert tx_json["chainID"] == "T"
-
-    # should be the two inner transactions created in the tests above
-    inner_transactions = tx_json["innerTransactions"]
-    assert len(inner_transactions) == 2
-
-    assert inner_transactions[0]["sender"] == "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th"
-    assert inner_transactions[0]["receiver"] == "erd1spyavw0956vq68xj8y4tenjpq2wd5a9p2c6j8gsz7ztyrnpxrruqzu66jx"
-    assert inner_transactions[0]["nonce"] == 77
-    assert inner_transactions[0]["relayer"] == "erd1k2s324ww2g0yj38qn2ch2jwctdy8mnfxep94q9arncc6xecg3xaq6mjse8"
-
-    assert inner_transactions[1]["sender"] == "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th"
-    assert inner_transactions[1]["receiver"] == "erd1fggp5ru0jhcjrp5rjqyqrnvhr3sz3v2e0fm3ktknvlg7mcyan54qzccnan"
-    assert inner_transactions[1]["nonce"] == 1234
-    assert inner_transactions[1]["relayer"] == "erd1k2s324ww2g0yj38qn2ch2jwctdy8mnfxep94q9arncc6xecg3xaq6mjse8"
 
 
 def _read_stdout(capsys: Any) -> str:

--- a/multiversx_sdk_cli/transactions.py
+++ b/multiversx_sdk_cli/transactions.py
@@ -2,7 +2,6 @@ import base64
 import json
 import logging
 import time
-from pathlib import Path
 from typing import Any, Dict, List, Optional, Protocol, TextIO
 
 from multiversx_sdk import (Address, Token, TokenComputer, TokenTransfer,
@@ -78,12 +77,6 @@ def do_prepare_transaction(args: Any) -> Transaction:
 
     if args.guardian:
         tx.guardian = args.guardian
-
-    if args.relayer:
-        tx.relayer = Address.new_from_bech32(args.relayer).to_bech32()
-
-    if args.inner_transactions:
-        tx.inner_transactions = load_inner_transactions_from_file(Path(args.inner_transactions).expanduser())
 
     tx.signature = bytes.fromhex(account.sign_transaction(tx))
     tx = sign_tx_by_guardian(args, tx)
@@ -227,11 +220,3 @@ def load_transaction_from_file(f: TextIO) -> Transaction:
 
     tx_converter = TransactionsConverter()
     return tx_converter.dictionary_to_transaction(transaction_dictionary)
-
-
-def load_inner_transactions_from_file(path: Path) -> List[Transaction]:
-    data_json = path.read_text()
-    transactions: List[Dict[str, Any]] = json.loads(data_json).get("innerTransactions")
-
-    tx_converter = TransactionsConverter()
-    return [tx_converter.dictionary_to_transaction(transaction) for transaction in transactions]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "multiversx-sdk-cli"
-version = "9.7.1"
+version = "9.8.0"
 authors = [
   { name="MultiversX" },
 ]


### PR DESCRIPTION
Removed the related relayed V3 code as it was postponed in the protocol. Since the feature never made it to mainnet, I've decided to bump just the **minor** version of the package, even though it is a breaking change.