### PR TITLE
Call sign-multiple-transactions when cosigning transactions using TCS

### DIFF
--- a/multiversx_sdk_cli/cosign_transaction.py
+++ b/multiversx_sdk_cli/cosign_transaction.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any
 
 import requests
 from multiversx_sdk import TransactionsConverter
@@ -11,20 +11,22 @@ def cosign_transaction(transaction: ITransaction, service_url: str, guardian_cod
     tx_converter = TransactionsConverter()
     payload = {
         "code": f"{guardian_code}",
-        "transaction": tx_converter.transaction_to_dictionary(transaction)
+        "transactions": [tx_converter.transaction_to_dictionary(transaction)]
     }
 
-    url = f"{service_url}/sign-transaction"
+    # we call sign-multiple-transactions to be allowed a bigger payload (e.g. deploying large contracts)
+    url = f"{service_url}/sign-multiple-transactions"
     response = requests.post(url, json=payload)
     check_for_guardian_error(response.json())
 
-    tx_as_dict = response.json()["data"]["transaction"]
+    # we only send 1 transaction
+    tx_as_dict = response.json()["data"]["transactions"][0]
     transaction.guardian_signature = bytes.fromhex(tx_as_dict["guardianSignature"])
 
     return transaction
 
 
-def check_for_guardian_error(response: Dict[str, Any]):
+def check_for_guardian_error(response: dict[str, Any]):
     error = response["error"]
 
     if error:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "multiversx-sdk-cli"
-version = "9.10.1"
+version = "9.10.2"
 authors = [
   { name="MultiversX" },
 ]


### PR DESCRIPTION
Changed the TCS endpoint that was used for co-signing to be allowed a larger payload. e.g. deploy large contracts