### PR TITLE
Add output format: private key in hexadecimal

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -1939,7 +1939,7 @@ options:
   --outfile OUTFILE                               path to the output file
   --in-format {raw-mnemonic,keystore-mnemonic,keystore-secret-key,pem}
                                                   the format of the input file
-  --out-format {raw-mnemonic,keystore-mnemonic,keystore-secret-key,pem,address-bech32,address-hex}
+  --out-format {raw-mnemonic,keystore-mnemonic,keystore-secret-key,pem,address-bech32,address-hex,private-hex}
                                                   the format of the output file
   --address-index ADDRESS_INDEX                   the address index, if input format is raw-mnemonic, keystore-mnemonic
                                                   or pem (with multiple entries) and the output format is keystore-

--- a/multiversx_sdk_cli/cli_wallet.py
+++ b/multiversx_sdk_cli/cli_wallet.py
@@ -25,6 +25,7 @@ WALLET_FORMAT_KEYSTORE_SECRET_KEY = "keystore-secret-key"
 WALLET_FORMAT_PEM = "pem"
 WALLET_FORMAT_ADDRESS_BECH32 = "address-bech32"
 WALLET_FORMAT_ADDRESS_HEX = "address-hex"
+WALLET_FORMAT_PRIVATE_HEX = "private-hex"
 
 WALLET_FORMATS = [
     WALLET_FORMAT_RAW_MNEMONIC,
@@ -33,7 +34,7 @@ WALLET_FORMATS = [
     WALLET_FORMAT_PEM,
 ]
 
-WALLET_FORMATS_AND_ADDRESSES = [*WALLET_FORMATS, WALLET_FORMAT_ADDRESS_BECH32, WALLET_FORMAT_ADDRESS_HEX]
+WALLET_FORMATS_AND_ADDRESSES = [*WALLET_FORMATS, WALLET_FORMAT_ADDRESS_BECH32, WALLET_FORMAT_ADDRESS_HEX, WALLET_FORMAT_PRIVATE_HEX]
 
 MAX_ITERATIONS_FOR_GENERATING_WALLET = 100
 CURRENT_SHARDS = [i for i in range(NUMBER_OF_SHARDS)]
@@ -281,6 +282,13 @@ def _create_wallet_content(
 
         pubkey = secret_key.generate_public_key()
         return pubkey.hex()
+
+    if out_format == WALLET_FORMAT_PRIVATE_HEX:
+        if mnemonic:
+            secret_key = mnemonic.derive_key(address_index)
+        assert secret_key is not None
+
+        return secret_key.hex()
 
     raise KnownError(f"Cannot create wallet, unknown output format: <{out_format}>. Make sure to use one of following: {WALLET_FORMATS}.")
 

--- a/multiversx_sdk_cli/tests/test_cli_wallet.py
+++ b/multiversx_sdk_cli/tests/test_cli_wallet.py
@@ -255,6 +255,15 @@ def test_wallet_convert_pem_to_pubkey(capsys: Any):
     out = _read_stdout(capsys).strip("Output:\n\n")
     assert out == "0139472eff6886771a982f3083da5d421f24c29181e63888228dc81ca60d69e1"
 
+def test_wallet_convert_pem_to_private_hex(capsys: Any):
+    infile = testdata_path / "alice.pem"
+
+    main([
+        "wallet", "convert", "--infile", str(infile), "--in-format", "pem", "--out-format", "private-hex"
+    ])
+
+    out = _read_stdout(capsys).strip("Output:\n\n")
+    assert out == "413f42575f7f26fad3317a778771212fdb80245850981e48b58a4f25e344e8f9"
 
 def test_wallet_sign_message(capsys: Any):
     message = "test"


### PR DESCRIPTION
Hello!

This PR adds an option in the "wallet convert" routine, to export a wallet's private key in hexadecimal format (`private-hex`).

Command example:
`wallet convert --infile wallet.pem --in-format pem --out-format private-hex`

I wrote an unit test (`test_wallet_convert_pem_to_private_hex`), but I'm not sure how to execute it... 😅