### PR TITLE
Localnet: add support for Andromeda

### DIFF
--- a/multiversx_sdk_cli/localnet/node_config_toml.py
+++ b/multiversx_sdk_cli/localnet/node_config_toml.py
@@ -31,16 +31,20 @@ def patch_config(data: ConfigDict, config: ConfigRoot):
     data['VirtualMachine']['Querying']['WasmVMVersions'] = [{'StartEpoch': 0, 'Version': '*'}]
 
     # Adjust "ChainParametersByEpoch" (for Andromeda)
-    chain_parameters_by_epoch = data.get('ChainParametersByEpoch', [])
+    chain_parameters_by_epoch = data['GeneralSettings'].get('ChainParametersByEpoch', [])
 
     if chain_parameters_by_epoch:
-        # For convenience, we set the activation epoch to 0
-        chain_parameters_by_epoch["EnableEpoch"] = 0
-        chain_parameters_by_epoch["RoundDuration"] = config.general.round_duration_milliseconds
-        chain_parameters_by_epoch["ShardConsensusGroupSize"] = config.shards.consensus_size
-        chain_parameters_by_epoch["ShardMinNumNodes"] = config.shards.num_validators_per_shard
-        chain_parameters_by_epoch["MetachainConsensusGroupSize"] = config.metashard.consensus_size
-        chain_parameters_by_epoch["MetachainMinNumNodes"] = config.metashard.num_validators
+        # For convenience, keep a single entry ...
+        chain_parameters_by_epoch.clear()
+        chain_parameters_by_epoch.append({})
+
+        # ... and set the activation epoch to 0
+        chain_parameters_by_epoch[0]["EnableEpoch"] = 0
+        chain_parameters_by_epoch[0]["RoundDuration"] = config.general.round_duration_milliseconds
+        chain_parameters_by_epoch[0]["ShardConsensusGroupSize"] = config.shards.consensus_size
+        chain_parameters_by_epoch[0]["ShardMinNumNodes"] = config.shards.num_validators_per_shard
+        chain_parameters_by_epoch[0]["MetachainConsensusGroupSize"] = config.metashard.consensus_size
+        chain_parameters_by_epoch[0]["MetachainMinNumNodes"] = config.metashard.num_validators
 
 
 def patch_api(data: ConfigDict, config: ConfigRoot):

--- a/multiversx_sdk_cli/localnet/node_config_toml.py
+++ b/multiversx_sdk_cli/localnet/node_config_toml.py
@@ -30,6 +30,18 @@ def patch_config(data: ConfigDict, config: ConfigRoot):
     data['VirtualMachine']['Execution']['WasmVMVersions'] = [{'StartEpoch': 0, 'Version': '*'}]
     data['VirtualMachine']['Querying']['WasmVMVersions'] = [{'StartEpoch': 0, 'Version': '*'}]
 
+    # Adjust "ChainParametersByEpoch" (for Andromeda)
+    chain_parameters_by_epoch = data.get('ChainParametersByEpoch', [])
+
+    if chain_parameters_by_epoch:
+        # For convenience, we set the activation epoch to 0
+        chain_parameters_by_epoch["EnableEpoch"] = 0
+        chain_parameters_by_epoch["RoundDuration"] = config.general.round_duration_milliseconds
+        chain_parameters_by_epoch["ShardConsensusGroupSize"] = config.shards.consensus_size
+        chain_parameters_by_epoch["ShardMinNumNodes"] = config.shards.num_validators_per_shard
+        chain_parameters_by_epoch["MetachainConsensusGroupSize"] = config.metashard.consensus_size
+        chain_parameters_by_epoch["MetachainMinNumNodes"] = config.metashard.num_validators
+
 
 def patch_api(data: ConfigDict, config: ConfigRoot):
     routes = data['APIPackages']['transaction']['Routes']

--- a/multiversx_sdk_cli/localnet/step_start.py
+++ b/multiversx_sdk_cli/localnet/step_start.py
@@ -75,6 +75,7 @@ async def do_start(configfile: Path, stop_after_seconds: int):
             "--log-save",
             f"--log-level={loglevel}",
             "--log-logger-name",
+            "--log-correlation",
             f"--destination-shard-as-observer={observer.shard}",
             f"--rest-api-interface={observer.api_interface()}",
             "--operation-mode=historical-balances"
@@ -88,6 +89,7 @@ async def do_start(configfile: Path, stop_after_seconds: int):
             "--log-save",
             f"--log-level={loglevel}",
             "--log-logger-name",
+            "--log-correlation",
             f"--rest-api-interface={validator.api_interface()}"
         ], cwd=validator.folder, delay=NODES_START_DELAY))
 

--- a/multiversx_sdk_cli/localnet/step_start.py
+++ b/multiversx_sdk_cli/localnet/step_start.py
@@ -13,6 +13,8 @@ from multiversx_sdk_cli import workstation
 from multiversx_sdk_cli.localnet.config_root import ConfigRoot
 from multiversx_sdk_cli.localnet.constants import \
     NETWORK_MONITORING_INTERVAL_IN_SECONDS
+from multiversx_sdk_cli.localnet.step_config import \
+    copy_binaries_into_localnet_workspace
 
 logger = logging.getLogger("localnet")
 
@@ -37,6 +39,17 @@ def start(configfile: Path, stop_after_seconds: int):
 
 async def do_start(configfile: Path, stop_after_seconds: int):
     config = ConfigRoot.from_file(configfile)
+
+    logger.info("Copy (overwrite) binaries, in case they've changed between restarts.")
+
+    try:
+        # Do this on a best-effort basis.
+        # Though useful (e.g. when the developer is using "resolution" = "local" and works with the Protocol itself),
+        # this step is not strictly necessary, and might even fail in some cases
+        # (e.g. when localnet is embedded in a Docker container and some cleanup procedures are performed upon setting up the localnet).
+        copy_binaries_into_localnet_workspace(config)
+    except Exception as e:
+        logger.warning(f"Error while copying binaries: {e}")
 
     display_api_table(config)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "multiversx-sdk-cli"
-version = "9.11.0"
+version = "9.12.0"
 authors = [
   { name="MultiversX" },
 ]


### PR DESCRIPTION
If `ChainParametersByEpoch` is present in `config.toml` (Andromeda), handle it - adjust parameters (use convenient values).

Alter the process of (re)starting the localnet: (re)copy (overwrite) binaries, in case they've changed between restarts. Useful when the developer is using the localnet with `resolution` = `local` (and works with / is testing the Protocol itself).

Adjusted localnet logging, starting nodes with `--log-correlation`.