### PR TITLE
Add specific prefix for address arguments

### DIFF
--- a/multiversx_sdk_cli/contracts.py
+++ b/multiversx_sdk_cli/contracts.py
@@ -267,6 +267,10 @@ class SmartContract(BaseTransactionsController):
             elif arg.startswith(ADDRESS_PREFIX):
                 args.append(AddressValue.new_from_address(Address.new_from_bech32(arg[len(ADDRESS_PREFIX) :])))
             elif arg.startswith(MAINCHAIN_ADDRESS_HRP):
+                # this flow will be removed in the future
+                logger.warning(
+                    "Address argument has no prefix. This flow will be removed in the future. Please provide each address using the `addr:` prefix. (e.g. --arguments addr:erd1...)"
+                )
                 args.append(AddressValue.new_from_address(Address.new_from_bech32(arg)))
             elif arg.startswith(get_address_hrp()):
                 args.append(AddressValue.new_from_address(Address.new_from_bech32(arg)))

--- a/multiversx_sdk_cli/contracts.py
+++ b/multiversx_sdk_cli/contracts.py
@@ -36,6 +36,8 @@ HEX_PREFIX = "0x"
 FALSE_STR_LOWER = "false"
 TRUE_STR_LOWER = "true"
 STR_PREFIX = "str:"
+ADDRESS_PREFIX = "addr:"
+MAINCHAIN_ADDRESS_HRP = "erd"
 
 
 # fmt: off
@@ -262,6 +264,10 @@ class SmartContract(BaseTransactionsController):
                 args.append(BytesValue(self._hex_to_bytes(arg)))
             elif arg.isnumeric():
                 args.append(BigUIntValue(int(arg)))
+            elif arg.startswith(ADDRESS_PREFIX):
+                args.append(AddressValue.new_from_address(Address.new_from_bech32(arg[len(ADDRESS_PREFIX) :])))
+            elif arg.startswith(MAINCHAIN_ADDRESS_HRP):
+                args.append(AddressValue.new_from_address(Address.new_from_bech32(arg)))
             elif arg.startswith(get_address_hrp()):
                 args.append(AddressValue.new_from_address(Address.new_from_bech32(arg)))
             elif arg.lower() == FALSE_STR_LOWER:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
   "ledgercomm[hid]",
   "rich==13.3.4",
   "argcomplete==3.2.2",
-  "multiversx-sdk[ledger]==1.2.0b0"
+  "multiversx-sdk[ledger]==1.2.0"
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,9 +19,6 @@ classifiers = [
     "Intended Audience :: Developers"
 ]
 
-[tool.hatch.metadata]
-allow-direct-references = true
-
 dependencies = [
   "toml>=0.10.2",
   "requests>=2.32.0,<3.0.0",
@@ -29,7 +26,7 @@ dependencies = [
   "ledgercomm[hid]",
   "rich==13.3.4",
   "argcomplete==3.2.2",
-  "multiversx-sdk @ git+https://github.com/multiversx/mx-sdk-py@feat/next"
+  "multiversx-sdk[ledger]==1.2.0b0"
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
   "ledgercomm[hid]",
   "rich==13.3.4",
   "argcomplete==3.2.2",
-  "multiversx-sdk[ledger]==1.1.0"
+  "multiversx-sdk @ git+https://github.com/multiversx/mx-sdk-py@feat/next"
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,9 @@ classifiers = [
     "Intended Audience :: Developers"
 ]
 
+[tool.hatch.metadata]
+allow-direct-references = true
+
 dependencies = [
   "toml>=0.10.2",
   "requests>=2.32.0,<3.0.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,4 @@ ledgercomm[hid]
 rich==13.3.4
 argcomplete==3.2.2
 
-# multiversx-sdk[ledger]==1.1.0
-git+https://github.com/multiversx/mx-sdk-py@feat/next#egg=multiversx_sdk
+multiversx-sdk[ledger]==1.2.0


### PR DESCRIPTION
Whenever an address is provided as an smart contract call argument, the `addr:` prefix should be used.
e.g.
```
mxpy contract call ... --arguments addr:erd1...
```