### PR TITLE
Update publish workflow to publish package to mxpy

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ permissions:
   contents: read
 
 jobs:
-  deploy:
+  deploy-mx-sdk-py-cli:
 
     runs-on: ubuntu-latest
 
@@ -34,6 +34,35 @@ jobs:
     - name: Build package
       run: python -m build
     - name: Publish package
+      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}
+
+  deploy-mxpy:
+    runs-on: ubuntu-latest
+    needs: deploy-mx-sdk-py-cli  # Ensure main package is published first
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.x'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
+
+    - name: Change package name for mxpy
+      run: sed -i 's/name = "multiversx-sdk-cli"/name = "mxpy"/' pyproject.toml
+
+    - name: Build and publish mxpy package
+      run: python -m build
+
+    - name: Publish mxpy package
       uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
       with:
         user: __token__


### PR DESCRIPTION
This will also publish the same package under the `mxpy` name, so people can simply do:
```sh
pipx install mxpy
```