### PR TITLE
Set log level from config or cli args

### DIFF
--- a/multiversx_sdk_cli/cli.py
+++ b/multiversx_sdk_cli/cli.py
@@ -53,6 +53,7 @@ def _do_main(cli_args: list[str]):
     parser = setup_parser(cli_args)
     argcomplete.autocomplete(parser)
 
+    _handle_log_level_argument(cli_args)
     _handle_verbose_argument(cli_args)
     args = parser.parse_args(cli_args)
 
@@ -64,8 +65,9 @@ def _do_main(cli_args: list[str]):
             handlers=[RichHandler(show_time=False, rich_tracebacks=True)],
         )
     else:
+        level: str = args.log_level
         logging.basicConfig(
-            level="INFO",
+            level=level.upper(),
             format="%(name)s: %(message)s",
             handlers=[RichHandler(show_time=False, rich_tracebacks=True)],
         )
@@ -111,6 +113,13 @@ See:
         version=f"MultiversX Python CLI (mxpy) {version}",
     )
     parser.add_argument("--verbose", action="store_true", default=False)
+    parser.add_argument(
+        "--log-level",
+        type=str,
+        default=config.get_log_level_from_config(),
+        choices=["debug", "info", "warning", "error"],
+        help="default: %(default)s",
+    )
 
     subparsers = parser.add_subparsers()
     commands: list[Any] = []
@@ -163,6 +172,17 @@ def _handle_verbose_argument(args: list[str]):
     if verbose_arg in args:
         args.remove(verbose_arg)
         args.insert(0, verbose_arg)
+
+
+def _handle_log_level_argument(args: list[str]):
+    log_level_arg = "--log-level"
+
+    if log_level_arg in args:
+        index = args.index(log_level_arg)
+        log_arg = args.pop(index)
+        log_value = args.pop(index)
+        args.insert(0, log_value)
+        args.insert(0, log_arg)
 
 
 if __name__ == "__main__":

--- a/multiversx_sdk_cli/config.py
+++ b/multiversx_sdk_cli/config.py
@@ -136,7 +136,16 @@ def get_defaults() -> dict[str, Any]:
         "dependencies.testwallets.urlTemplate.osx": "https://github.com/multiversx/mx-sdk-testwallets/archive/{TAG}.tar.gz",
         "dependencies.testwallets.urlTemplate.windows": "https://github.com/multiversx/mx-sdk-testwallets/archive/{TAG}.tar.gz",
         "github_api_token": "",
+        "log_level": "info",
     }
+
+
+def get_log_level_from_config():
+    log_level = get_value("log_level")
+    if log_level not in ["debug", "info", "warning", "error"]:
+        raise errors.LogLevelError(log_level)
+
+    return log_level
 
 
 def get_deprecated_entries_in_config_file():

--- a/multiversx_sdk_cli/errors.py
+++ b/multiversx_sdk_cli/errors.py
@@ -211,3 +211,8 @@ class InvalidAddressConfigValue(KnownError):
 class AddressConfigFileError(KnownError):
     def __init__(self, message: str):
         super().__init__(message)
+
+
+class LogLevelError(KnownError):
+    def __init__(self, log_level: str):
+        super().__init__(f"Log level not accepted: {log_level}. Choose between ['debug', 'info', 'warning', 'error'].")


### PR DESCRIPTION
An user can set the `log_level` config entry using `mxpy config set log_level error`. The allowed values are [debug, info, warning, error]. The default value is `info`.

Additionally, the `--log-level` argument can be provided with any `mxpy` command. Explicitly specifying this argument will override the value set in the config.