### PR TITLE
Fixes after audit

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -3057,6 +3057,22 @@ options:
   -h, --help  show this help message and exit
 
 ```
+### Configuration.Delete
+
+
+```
+$ mxpy config delete --help
+usage: mxpy config delete [-h] ...
+
+Deletes a configuration value from the active configuration.
+
+positional arguments:
+  name        the name of the configuration entry
+
+options:
+  -h, --help  show this help message and exit
+
+```
 ### Configuration.Reset
 
 
@@ -5846,6 +5862,35 @@ options:
   --proxy-headers KEY=VALUE [KEY=VALUE ...]  custom HTTP headers for proxy requests, e.g. 'Api-Key=mytoken'
 
 ```
+### Governance.GetProposal
+
+
+```
+$ mxpy governance get-proposal --help
+usage: mxpy governance get-proposal [-h] ...
+
+Get info about a proposal.
+
+Output example:
+===============
+{
+    "emittedTransaction": {
+        "nonce": 42,
+        "sender": "alice",
+        "receiver": "bob",
+        "...": "..."
+    },
+    "emittedTransactionData": "the transaction data, not encoded",
+    "emittedTransactionHash": "the transaction hash"
+}
+
+options:
+  -h, --help                                 show this help message and exit
+  --proposal-nonce PROPOSAL_NONCE            the nonce of the proposal
+  --proxy PROXY                              🔗 the URL of the proxy
+  --proxy-headers KEY=VALUE [KEY=VALUE ...]  custom HTTP headers for proxy requests, e.g. 'Api-Key=mytoken'
+
+```
 ## Group **ConfigEnv**
 
 
@@ -5966,6 +6011,23 @@ List available environments
 
 options:
   -h, --help  show this help message and exit
+
+```
+### ConfigEnv.Delete
+
+
+```
+$ mxpy config-env delete --help
+usage: mxpy config-env delete [-h] ...
+
+Deletes an env value from the specified environment.
+
+positional arguments:
+  name        the name of the configuration entry
+
+options:
+  -h, --help  show this help message and exit
+  --env ENV   the name of the environment to operate on
 
 ```
 ### ConfigEnv.Remove
@@ -6275,6 +6337,37 @@ options:
   --hash HASH                                the transaction hash
 
 ```
+### Get.NetworkConfig
+
+
+```
+$ mxpy get network-config --help
+usage: mxpy get network-config [-h] ...
+
+Get the network configuration.
+
+options:
+  -h, --help                                 show this help message and exit
+  --proxy PROXY                              🔗 the URL of the proxy
+  --proxy-headers KEY=VALUE [KEY=VALUE ...]  custom HTTP headers for proxy requests, e.g. 'Api-Key=mytoken'
+
+```
+### Get.NetworkStatus
+
+
+```
+$ mxpy get network-status --help
+usage: mxpy get network-status [-h] ...
+
+Get the network status.
+
+options:
+  -h, --help                                 show this help message and exit
+  --proxy PROXY                              🔗 the URL of the proxy
+  --proxy-headers KEY=VALUE [KEY=VALUE ...]  custom HTTP headers for proxy requests, e.g. 'Api-Key=mytoken'
+  --shard {0,1,2,4294967295}                 the shard to get the status for (default: 4294967295, which is methachain)
+
+```
 ## Group **Token**
 
 
@@ -6416,6 +6509,75 @@ $ mxpy token issue-non-fungible --help
 usage: mxpy token issue-non-fungible [-h] ...
 
 Issue a new non-fungible ESDT token (NFT).
+
+options:
+  -h, --help                                     show this help message and exit
+  --token-name TOKEN_NAME                        the name of the token to be issued: 3-20 alphanumerical characters
+  --token-ticker TOKEN_TICKER                    the ticker of the token to be issued: 3-10 UPPERCASE alphanumerical
+                                                 characters
+  --cannot-freeze                                make token not freezable
+  --cannot-wipe                                  make token not wipeable
+  --cannot-pause                                 make token not pausable
+  --cannot-change-owner                          don't allow changing the token's owner
+  --cannot-upgrade                               don't allow upgrading the token
+  --cannot-add-special-roles                     don't allow special roles to be added for the token
+  --cannot-transfer-nft-create-role              don't allow for nft create roles to be transferred for the token
+  --sender SENDER                                the alias of the wallet set in the address config
+  --pem PEM                                      🔑 the PEM file, if keyfile not provided
+  --keyfile KEYFILE                              🔑 a JSON keyfile, if PEM not provided
+  --passfile PASSFILE                            DEPRECATED, do not use it anymore. Instead, you'll be prompted to enter
+                                                 the password.
+  --ledger                                       🔐 bool flag for signing transaction using ledger
+  --sender-wallet-index SENDER_WALLET_INDEX      🔑 the address index; can be used for PEM files, keyfiles of type
+                                                 mnemonic or Ledger devices (default: 0)
+  --sender-username SENDER_USERNAME              🖄 the username of the sender
+  --hrp HRP                                      The hrp used to convert the address to its bech32 representation
+  --nonce NONCE                                  # the nonce for the transaction. If not provided, is fetched from the
+                                                 network.
+  --gas-price GAS_PRICE                          ⛽ the gas price (default: 1000000000)
+  --gas-limit GAS_LIMIT                          ⛽ the gas limit
+  --gas-limit-multiplier GAS_LIMIT_MULTIPLIER    if `--gas-limit` is not provided, the estimated value will be
+                                                 multiplied by this multiplier (e.g 1.1)
+  --value VALUE                                  the value to transfer (default: 0)
+  --chain CHAIN                                  the chain identifier
+  --version VERSION                              the transaction version (default: 2)
+  --options OPTIONS                              the transaction options (default: 0)
+  --relayer RELAYER                              the bech32 address of the relayer
+  --guardian GUARDIAN                            the bech32 address of the guardian
+  --proxy PROXY                                  🔗 the URL of the proxy
+  --proxy-headers KEY=VALUE [KEY=VALUE ...]      custom HTTP headers for proxy requests, e.g. 'Api-Key=mytoken'
+  --send                                         ✓ whether to broadcast the transaction (default: False)
+  --simulate                                     whether to simulate the transaction (default: False)
+  --wait-result                                  signal to wait for the transaction result - only valid if --send is set
+  --timeout TIMEOUT                              max num of seconds to wait for result - only valid if --wait-result is
+                                                 set
+  --guardian-service-url GUARDIAN_SERVICE_URL    the url of the guardian service
+  --guardian-2fa-code GUARDIAN_2FA_CODE          the 2fa code for the guardian
+  --guardian-pem GUARDIAN_PEM                    🔑 the PEM file, if keyfile not provided
+  --guardian-keyfile GUARDIAN_KEYFILE            🔑 a JSON keyfile, if PEM not provided
+  --guardian-passfile GUARDIAN_PASSFILE          DEPRECATED, do not use it anymore. Instead, you'll be prompted to enter
+                                                 the password.
+  --guardian-ledger                              🔐 bool flag for signing transaction using ledger
+  --guardian-wallet-index GUARDIAN_WALLET_INDEX  🔑 the address index; can be used for PEM files, keyfiles of type
+                                                 mnemonic or Ledger devices (default: 0)
+  --relayer-pem RELAYER_PEM                      🔑 the PEM file, if keyfile not provided
+  --relayer-keyfile RELAYER_KEYFILE              🔑 a JSON keyfile, if PEM not provided
+  --relayer-passfile RELAYER_PASSFILE            DEPRECATED, do not use it anymore. Instead, you'll be prompted to enter
+                                                 the password.
+  --relayer-ledger                               🔐 bool flag for signing transaction using ledger
+  --relayer-wallet-index RELAYER_WALLET_INDEX    🔑 the address index; can be used for PEM files, keyfiles of type
+                                                 mnemonic or Ledger devices (default: 0)
+  --outfile OUTFILE                              where to save the output (default: stdout)
+
+```
+### Token.IssueSemiFungible
+
+
+```
+$ mxpy token issue-semi-fungible --help
+usage: mxpy token issue-semi-fungible [-h] ...
+
+Issue a new semi-fungible ESDT token.
 
 options:
   -h, --help                                     show this help message and exit
@@ -8998,5 +9160,223 @@ options:
   --relayer-wallet-index RELAYER_WALLET_INDEX    🔑 the address index; can be used for PEM files, keyfiles of type
                                                  mnemonic or Ledger devices (default: 0)
   --outfile OUTFILE                              where to save the output (default: stdout)
+
+```
+## Group **Dns**
+
+
+```
+$ mxpy dns --help
+usage: mxpy dns COMMAND [-h] ...
+
+Operations related to the Domain Name Service
+
+COMMANDS:
+  {register,resolve,validate-name,name-hash,registration-cost,version,dns-addresses,dns-address-for-name,dns-address-for-name-hex}
+
+OPTIONS:
+  -h, --help            show this help message and exit
+
+----------------
+COMMANDS summary
+----------------
+register                       Send a register transaction to the appropriate DNS contract from given user and with given name
+resolve                        Find the address for a name
+validate-name                  Asks one of the DNS contracts to validate a name. Can be useful before registering it.
+name-hash                      The hash of a name, as computed by a DNS smart contract
+registration-cost              Gets the registration cost from a DNS smart contract, by default the one with shard id 0.
+version                        Asks the contract for its version
+dns-addresses                  Lists all 256 DNS contract addresses
+dns-address-for-name           DNS contract address (bech32) that corresponds to a name
+dns-address-for-name-hex       DNS contract address (hex) that corresponds to a name
+
+```
+### Dns.DnsAddressForName
+
+
+```
+$ mxpy dns dns-address-for-name --help
+usage: mxpy dns dns-address-for-name [-h] ...
+
+DNS contract address (bech32) that corresponds to a name
+
+positional arguments:
+  name        the name for which to check
+
+options:
+  -h, --help  show this help message and exit
+
+```
+### Dns.DnsAddressForNameHex
+
+
+```
+$ mxpy dns dns-address-for-name-hex --help
+usage: mxpy dns dns-address-for-name-hex [-h] ...
+
+DNS contract address (hex) that corresponds to a name
+
+positional arguments:
+  name        the name for which to check
+
+options:
+  -h, --help  show this help message and exit
+
+```
+### Dns.DnsAddresses
+
+
+```
+$ mxpy dns dns-addresses --help
+usage: mxpy dns dns-addresses [-h] ...
+
+Lists all 256 DNS contract addresses
+
+options:
+  -h, --help  show this help message and exit
+
+```
+### Dns.NameHash
+
+
+```
+$ mxpy dns name-hash --help
+usage: mxpy dns name-hash [-h] ...
+
+The hash of a name, as computed by a DNS smart contract
+
+positional arguments:
+  name        the name for which to check
+
+options:
+  -h, --help  show this help message and exit
+
+```
+### Dns.Register
+
+
+```
+$ mxpy dns register --help
+usage: mxpy dns register [-h] ...
+
+Send a register transaction to the appropriate DNS contract from given user and with given name
+
+options:
+  -h, --help                                     show this help message and exit
+  --outfile OUTFILE                              where to save the output (default: stdout)
+  --send                                         ✓ whether to broadcast the transaction (default: False)
+  --simulate                                     whether to simulate the transaction (default: False)
+  --sender SENDER                                the alias of the wallet set in the address config
+  --pem PEM                                      🔑 the PEM file, if keyfile not provided
+  --keyfile KEYFILE                              🔑 a JSON keyfile, if PEM not provided
+  --passfile PASSFILE                            DEPRECATED, do not use it anymore. Instead, you'll be prompted to enter
+                                                 the password.
+  --ledger                                       🔐 bool flag for signing transaction using ledger
+  --sender-wallet-index SENDER_WALLET_INDEX      🔑 the address index; can be used for PEM files, keyfiles of type
+                                                 mnemonic or Ledger devices (default: 0)
+  --sender-username SENDER_USERNAME              🖄 the username of the sender
+  --hrp HRP                                      The hrp used to convert the address to its bech32 representation
+  --proxy PROXY                                  🔗 the URL of the proxy
+  --proxy-headers KEY=VALUE [KEY=VALUE ...]      custom HTTP headers for proxy requests, e.g. 'Api-Key=mytoken'
+  --nonce NONCE                                  # the nonce for the transaction. If not provided, is fetched from the
+                                                 network.
+  --gas-price GAS_PRICE                          ⛽ the gas price (default: 1000000000)
+  --gas-limit GAS_LIMIT                          ⛽ the gas limit
+  --gas-limit-multiplier GAS_LIMIT_MULTIPLIER    if `--gas-limit` is not provided, the estimated value will be
+                                                 multiplied by this multiplier (e.g 1.1)
+  --value VALUE                                  the value to transfer (default: 0)
+  --chain CHAIN                                  the chain identifier
+  --version VERSION                              the transaction version (default: 2)
+  --options OPTIONS                              the transaction options (default: 0)
+  --relayer RELAYER                              the bech32 address of the relayer
+  --guardian GUARDIAN                            the bech32 address of the guardian
+  --guardian-service-url GUARDIAN_SERVICE_URL    the url of the guardian service
+  --guardian-2fa-code GUARDIAN_2FA_CODE          the 2fa code for the guardian
+  --guardian-pem GUARDIAN_PEM                    🔑 the PEM file, if keyfile not provided
+  --guardian-keyfile GUARDIAN_KEYFILE            🔑 a JSON keyfile, if PEM not provided
+  --guardian-passfile GUARDIAN_PASSFILE          DEPRECATED, do not use it anymore. Instead, you'll be prompted to enter
+                                                 the password.
+  --guardian-ledger                              🔐 bool flag for signing transaction using ledger
+  --guardian-wallet-index GUARDIAN_WALLET_INDEX  🔑 the address index; can be used for PEM files, keyfiles of type
+                                                 mnemonic or Ledger devices (default: 0)
+  --relayer-pem RELAYER_PEM                      🔑 the PEM file, if keyfile not provided
+  --relayer-keyfile RELAYER_KEYFILE              🔑 a JSON keyfile, if PEM not provided
+  --relayer-passfile RELAYER_PASSFILE            DEPRECATED, do not use it anymore. Instead, you'll be prompted to enter
+                                                 the password.
+  --relayer-ledger                               🔐 bool flag for signing transaction using ledger
+  --relayer-wallet-index RELAYER_WALLET_INDEX    🔑 the address index; can be used for PEM files, keyfiles of type
+                                                 mnemonic or Ledger devices (default: 0)
+  --name NAME                                    the name to register
+
+```
+### Dns.RegistrationCost
+
+
+```
+$ mxpy dns registration-cost --help
+usage: mxpy dns registration-cost [-h] ...
+
+Gets the registration cost from a DNS smart contract, by default the one with shard id 0.
+
+options:
+  -h, --help                                 show this help message and exit
+  --shard-id SHARD_ID                        shard id of the contract to call (default: 0)
+  --proxy PROXY                              🔗 the URL of the proxy
+  --proxy-headers KEY=VALUE [KEY=VALUE ...]  custom HTTP headers for proxy requests, e.g. 'Api-Key=mytoken'
+
+```
+### Dns.Resolve
+
+
+```
+$ mxpy dns resolve --help
+usage: mxpy dns resolve [-h] ...
+
+Find the address for a name
+
+positional arguments:
+  name                                       the name for which to check
+
+options:
+  -h, --help                                 show this help message and exit
+  --proxy PROXY                              🔗 the URL of the proxy
+  --proxy-headers KEY=VALUE [KEY=VALUE ...]  custom HTTP headers for proxy requests, e.g. 'Api-Key=mytoken'
+
+```
+### Dns.ValidateName
+
+
+```
+$ mxpy dns validate-name --help
+usage: mxpy dns validate-name [-h] ...
+
+Asks one of the DNS contracts to validate a name. Can be useful before registering it.
+
+positional arguments:
+  name                                       the name for which to check
+
+options:
+  -h, --help                                 show this help message and exit
+  --shard-id SHARD_ID                        shard id of the contract to call (default: 0)
+  --proxy PROXY                              🔗 the URL of the proxy
+  --proxy-headers KEY=VALUE [KEY=VALUE ...]  custom HTTP headers for proxy requests, e.g. 'Api-Key=mytoken'
+
+```
+### Dns.Version
+
+
+```
+$ mxpy dns version --help
+usage: mxpy dns version [-h] ...
+
+Asks the contract for its version
+
+options:
+  -h, --help                                 show this help message and exit
+  --shard-id SHARD_ID                        shard id of the contract to call (default: 0)
+  --all                                      prints a list of all DNS contracts and their current versions (default:
+                                             False)
+  --proxy PROXY                              🔗 the URL of the proxy
+  --proxy-headers KEY=VALUE [KEY=VALUE ...]  custom HTTP headers for proxy requests, e.g. 'Api-Key=mytoken'
 
 ```

--- a/CLI.md.sh
+++ b/CLI.md.sh
@@ -122,6 +122,7 @@ generate() {
     command "Configuration.New" "config new"
     command "Configuration.Switch" "config switch"
     command "Configuration.List" "config list"
+    command "Configuration.Delete" "config delete"
     command "Configuration.Reset" "config reset"
 
     group "Data" "data"
@@ -184,6 +185,7 @@ generate() {
     command "Governance.GetVotingPower" "governance get-voting-power"
     command "Governance.GetConfig" "governance get-config"
     command "Governance.GetDelegatedVoteInfo" "governance get-delegated-vote-info"
+    command "Governance.GetProposal" "governance get-proposal"
 
     group "ConfigEnv" "config-env"
     command "ConfigEnv.New" "config-env new"
@@ -192,6 +194,7 @@ generate() {
     command "ConfigEnv.Dump" "config-env dump"
     command "ConfigEnv.Switch" "config-env switch"
     command "ConfigEnv.List" "config-env list"
+    command "ConfigEnv.Delete" "config-env delete"
     command "ConfigEnv.Remove" "config-env remove"
     command "ConfigEnv.Reset" "config-env reset"
 
@@ -212,10 +215,13 @@ generate() {
     command "Get.StorageEntry" "get storage-entry"
     command "Get.Token" "get token"
     command "Get.Transaction" "get transaction"
+    command "Get.NetworkConfig" "get network-config"
+    command "Get.NetworkStatus" "get network-status"
 
     group "Token" "token"
     command "Token.IssueFungbile" "token issue-fungible"
     command "Token.IssueNonFungbile" "token issue-non-fungible"
+    command "Token.IssueSemiFungible" "token issue-semi-fungible"
     command "Token.RegisterMetaEsdt" "token register-meta-esdt"
     command "Token.RegisterAndSetAllRoles" "token register-and-set-all-roles"
     command "Token.SetBurnRoleGlobally" "token set-burn-role-globally"
@@ -256,6 +262,17 @@ generate() {
     command "Token.StopNftCreation" "token stop-nft-creation"
     command "Token.WipeSingleNft" "token wipe-single-nft"
     command "Token.AddUris" "token add-uris"
+
+    group "Dns" "dns"
+    command "Dns.DnsAddressForName" "dns dns-address-for-name"
+    command "Dns.DnsAddressForNameHex" "dns dns-address-for-name-hex"
+    command "Dns.DnsAddresses" "dns dns-addresses"
+    command "Dns.NameHash" "dns name-hash"
+    command "Dns.Register" "dns register"
+    command "Dns.RegistrationCost" "dns registration-cost"
+    command "Dns.Resolve" "dns resolve"
+    command "Dns.ValidateName" "dns validate-name"
+    command "Dns.Version" "dns version"
 }
 
 generate

--- a/multiversx_sdk_cli/cli_contracts.py
+++ b/multiversx_sdk_cli/cli_contracts.py
@@ -592,6 +592,7 @@ def unverify(args: Any) -> None:
 
     headers = {"Content-type": "application/json"}
     response = requests.delete(verifier_url, json=request_payload, headers=headers)
+    response.raise_for_status()
     logger.info(f"Your request to unverify contract {contract} was submitted.")
     print(response.json().get("message"))
 

--- a/multiversx_sdk_cli/cli_dns.py
+++ b/multiversx_sdk_cli/cli_dns.py
@@ -37,7 +37,7 @@ def setup_parser(args: list[str], subparsers: Any) -> Any:
     cli_shared.add_tx_args(args, sub, with_receiver=False, with_data=False)
     cli_shared.add_guardian_wallet_args(args, sub)
     cli_shared.add_relayed_v3_wallet_args(args, sub)
-    sub.add_argument("--name", help="the name to register")
+    sub.add_argument("--name", required=True, help="the name to register")
     sub.set_defaults(func=register)
 
     sub = cli_shared.add_command_subparser(subparsers, "dns", "resolve", "Find the address for a name")

--- a/multiversx_sdk_cli/cli_get.py
+++ b/multiversx_sdk_cli/cli_get.py
@@ -202,7 +202,7 @@ def get_network_config(args: Any):
 
 def get_network_status(args: Any):
     proxy = _get_proxy(args)
-    status = proxy.get_network_status()
+    status = proxy.get_network_status(args.shard)
 
     dump_out_json(status.raw)
 

--- a/multiversx_sdk_cli/cli_shared.py
+++ b/multiversx_sdk_cli/cli_shared.py
@@ -361,6 +361,7 @@ def add_wait_result_and_timeout_args(sub: Any):
     )
     sub.add_argument(
         "--timeout",
+        type=int,
         default=100,
         help="max num of seconds to wait for result" " - only valid if --wait-result is set",
     )
@@ -812,6 +813,12 @@ def prepare_token_transfers(transfers: list[str]) -> list[TokenTransfer]:
     """Converts a list of token transfers as received from the CLI to a list of TokenTransfer objects."""
     token_computer = TokenComputer()
     token_transfers: list[TokenTransfer] = []
+
+    if len(transfers) % 2 != 0:
+        raise ArgumentsNotProvidedError(
+            "Invalid number of arguments for token transfers. "
+            "Expected pairs of [token, amount], but got an odd number of arguments."
+        )
 
     for i in range(0, len(transfers) - 1, 2):
         extended_identifier = transfers[i]

--- a/multiversx_sdk_cli/cli_transactions.py
+++ b/multiversx_sdk_cli/cli_transactions.py
@@ -206,6 +206,9 @@ def sign_transaction(args: Any):
         if tx.guardian and not tx_computer.has_options_set_for_guarded_transaction(tx):
             raise BadUsage("Guardian wallet provided but the transaction has incorrect options")
 
+    if not sender and not guardian and not relayer:
+        raise NoWalletProvided()
+
     guardian_and_relayer = GuardianRelayerData(
         guardian=guardian,
         guardian_address=tx.guardian,

--- a/multiversx_sdk_cli/contract_verification.py
+++ b/multiversx_sdk_cli/contract_verification.py
@@ -146,6 +146,7 @@ def query_status_with_task_id(url: str, task_id: str, interval: int = 10):
 def _do_post(url: str, payload: Any) -> tuple[int, str, dict[str, Any]]:
     logger.debug(f"_do_post() to {url}")
     response = requests.post(url, json=payload)
+    response.raise_for_status()
 
     try:
         data = response.json()
@@ -159,6 +160,7 @@ def _do_post(url: str, payload: Any) -> tuple[int, str, dict[str, Any]]:
 def _do_get(url: str) -> tuple[int, str, dict[str, Any]]:
     logger.debug(f"_do_get() from {url}")
     response = requests.get(url)
+    response.raise_for_status()
 
     try:
         data = response.json()

--- a/multiversx_sdk_cli/cosign_transaction.py
+++ b/multiversx_sdk_cli/cosign_transaction.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 import requests
 from multiversx_sdk import Transaction
 
@@ -15,15 +13,11 @@ def cosign_transaction(transaction: Transaction, service_url: str, guardian_code
     # we call sign-multiple-transactions to be allowed a bigger payload (e.g. deploying large contracts)
     url = f"{service_url}/sign-multiple-transactions"
     response = requests.post(url, json=payload)
-    check_for_guardian_error(response.json())
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError as e:
+        raise GuardianServiceError(f"Guardian service returned an error: {str(e)}")
 
     # we only send 1 transaction
     tx_as_dict = response.json()["data"]["transactions"][0]
     transaction.guardian_signature = bytes.fromhex(tx_as_dict["guardianSignature"])
-
-
-def check_for_guardian_error(response: dict[str, Any]):
-    error = response["error"]
-
-    if error:
-        raise GuardianServiceError(error)

--- a/multiversx_sdk_cli/tests/test_shared.py
+++ b/multiversx_sdk_cli/tests/test_shared.py
@@ -1,7 +1,9 @@
+import pytest
 from multiversx_sdk import Address
 
 from multiversx_sdk_cli.args_converter import convert_args_to_typed_values
 from multiversx_sdk_cli.cli_shared import prepare_token_transfers
+from multiversx_sdk_cli.errors import ArgumentsNotProvidedError
 
 
 def test_prepare_token_tranfers():
@@ -36,6 +38,17 @@ def test_prepare_token_tranfers():
     assert transfers[3].amount == 123456789
 
 
+def test_prepare_invalid_token_tranfers():
+    # list of token transfers as interpreted by the CLI
+    token_transfers = [
+        "FNG-123456",
+        "10000",
+        "SFT-123123-0a",
+    ]
+    with pytest.raises(ArgumentsNotProvidedError):
+        prepare_token_transfers(token_transfers)
+
+
 def test_prepare_args_for_factories():
     args = [
         "0x5",
@@ -43,7 +56,7 @@ def test_prepare_args_for_factories():
         "false",
         "true",
         "str:test-string",
-        "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th",
+        "addr:erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th",
     ]
 
     arguments = convert_args_to_typed_values(args)


### PR DESCRIPTION
- Fixed `--timeout` parsing so explicit values are integers and no longer break transaction-result waiting.
- Added validation that rejects odd-length `--token-transfers` lists instead of silently dropping the final argument.
- Added a regression test for malformed token-transfer pairs.
- Fixed `get network-status --shard` so the selected shard is forwarded to the network provider.
- Made `--name` mandatory for dns register.
- Prevented tx sign from succeeding when no sender, guardian, or relayer wallet is available.
- Added HTTP status validation to contract verification, verification polling, and contract unverification requests.
- Improved guardian cosigner error handling by converting HTTP failures into GuardianServiceError.
- Updated a test address argument to use the supported `addr:` prefix, removing deprecated behavior.
- Expanded `CLI.md.sh` and regenerated `CLI.md` with 16 previously undocumented paths, including DNS, configuration deletion, network status/config, governance proposal, and semi-fungible token commands.